### PR TITLE
feat(tui): ratatui terminal dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [0.12.0] - 2026-04-01
+
+### Added
+- **Terminal dashboard** (`--features tui`): Live ratatui-powered system monitor for the daemon. Connects as a read-only client over the existing Unix socket — no audio code, no thread sync, open/close freely without affecting playback.
+- **Unified Stream panel**: Events and voices merged into a single feed. Each repo gets a stable lane color from an 8-color palette, shown as block-density prefixes (`█▓▒░`) that pulse on activity and decay over ~20 seconds.
+- **Stacked activity histogram**: 60-minute bar chart with per-category colored segments (tool=green, prompt=yellow, session=cyan, agent=blue). Direct buffer writes for cell-level color control — ratatui's Sparkline widget only supports single-color bars.
+- **Seed palette overlay**: Centered popup ([p] to open, Esc to close) showing all 16 curated seeds with groove params. Renders via `ratatui::widgets::Clear` + `List` with `ListState`.
+- **Event view reset**: Press [r] to clear displayed events and start counting fresh.
+- **Recency gradient**: Newest events flash white+bold for 2 seconds, then fade through full type color → DarkGray based on positional recency (`line_index / visible_count`).
+- **Event type parsing**: 16 hook event types mapped to 5 categories with per-type colors and compact labels (TOOL, PROMPT, START, FAIL, AGENT+, etc.).
+- **Voice activity tracking**: Per-repo Instant timestamps for real-time lane pulse effects.
+- **`docs/tui-design.md`**: Full design document with architecture, rendering techniques, and development diary.
+- 14 new TUI-specific tests (155 total with tui feature, 141 default, 142 tray)
+
+### Development Diary
+The TUI was built in a single session across three iterations:
+1. **v1 — Basic dashboard**: Split layout (voices left, seeds right, events bottom). Socket client ported from tray module. 7 tests.
+2. **v2 — Color and activity**: Event log parsing with per-type colors. 60-minute sparkline. Voice pulse indicators with block-density decay. Border flash on new events.
+3. **v3 — Unified stream**: Merged voices+events with colored lane prefixes. Stacked per-category activity bars via direct buffer writes. Seeds moved to popup overlay. Reset view. Inspired by user feedback: "Make this thing light up."
+
 ## [0.9.1] - 2026-03-14
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,13 +7,13 @@ Single-file Rust application (`src/main.rs`, ~8000 lines). Everything — CLI, h
 ## Build & Test
 
 ```bash
-cargo test                              # 141 tests, must pass with zero warnings
+cargo test                              # 147 tests, must pass with zero warnings
 cargo build --release                   # Optimized binary
 cargo install --path .                  # Install to ~/.cargo/bin/
-cargo test --features tray              # Tray tests also pass (142 total)
+cargo test --features tray              # Tray tests also pass (148 total)
 cargo build --release --features tray   # Build with macOS menu bar support
 cargo install --path . --features tray  # Install with tray support
-cargo test --features tui               # TUI tests (147 total)
+cargo test --features tui               # TUI tests (169 total)
 cargo build --release --features tui    # Build with terminal dashboard
 cargo install --path . --features tui   # Install with TUI support
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,17 +2,20 @@
 
 ## Architecture
 
-Single-file Rust application (`src/main.rs`, ~7000 lines). Everything — CLI, hashing, synthesis, audio output, step sequencer, menu bar tray — lives in one file.
+Single-file Rust application (`src/main.rs`, ~8000 lines). Everything — CLI, hashing, synthesis, audio output, step sequencer, menu bar tray, terminal dashboard — lives in one file.
 
 ## Build & Test
 
 ```bash
-cargo test                              # 139 tests, must pass with zero warnings
+cargo test                              # 141 tests, must pass with zero warnings
 cargo build --release                   # Optimized binary
 cargo install --path .                  # Install to ~/.cargo/bin/
-cargo test --features tray              # Tray tests also pass (140 total)
+cargo test --features tray              # Tray tests also pass (142 total)
 cargo build --release --features tray   # Build with macOS menu bar support
 cargo install --path . --features tray  # Install with tray support
+cargo test --features tui               # TUI tests (147 total)
+cargo build --release --features tui    # Build with terminal dashboard
+cargo install --path . --features tui   # Install with TUI support
 ```
 
 ## Key Concepts
@@ -21,6 +24,7 @@ cargo install --path . --features tray  # Install with tray support
 - **Event seeds**: each Claude Code hook event gets a unique seed that rotates pattern, pad shape, and drum hit type — same repo sounds different per event
 - **Deterministic**: same inputs always produce the same sound
 - **Tray app** (macOS, `--features tray`): menu bar icon for daemon monitoring/control via `objc2-app-kit`. Separate process communicating over the daemon's Unix socket. Feature-gated to keep default build lean
+- **TUI dashboard** (`--features tui`): ratatui-powered terminal dashboard showing live daemon state (voices, seeds, events, controls). Connects as a client to the daemon's Unix socket. Cross-platform, feature-gated
 
 ## Runtime Files
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "branch-tone"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "branch-tone"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "alsa"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "branch-tone"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -128,6 +134,7 @@ dependencies = [
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
+ "ratatui",
  "serde_json",
  "sha2",
 ]
@@ -143,6 +150,21 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cesu8"
@@ -210,6 +232,20 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
 ]
 
 [[package]]
@@ -297,6 +333,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dasp_sample"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,6 +414,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -358,6 +434,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "futures-core"
@@ -406,6 +488,17 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
@@ -417,13 +510,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -431,6 +552,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -506,6 +636,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "mach2"
@@ -836,6 +975,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -872,6 +1017,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags 2.10.0",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -912,6 +1078,12 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -1025,10 +1197,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "syn"
@@ -1102,6 +1302,35 @@ name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "branch-tone"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2024"
 authors = ["Ramzi Abdoch"]
 description = "Generate unique musical tones from git branch names"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "branch-tone"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 authors = ["Ramzi Abdoch"]
 description = "Generate unique musical tones from git branch names"
@@ -68,6 +68,13 @@ dirs = "5.0"
 # -----------------------------------------------------------------------------
 crossterm = "0.28"
 
+# -----------------------------------------------------------------------------
+# Ratatui - Terminal User Interface framework (immediate-mode, buffer-diffing)
+# Used by `branch-tone tui` to render a live dashboard of daemon state.
+# Uses crossterm (already a dependency) as its backend.
+# -----------------------------------------------------------------------------
+ratatui = { version = "0.29", optional = true, default-features = false, features = ["crossterm"] }
+
 # =============================================================================
 # Features - optional functionality behind feature flags
 # =============================================================================
@@ -75,6 +82,7 @@ crossterm = "0.28"
 [features]
 default = []
 tray = ["dep:objc2", "dep:objc2-app-kit", "dep:objc2-foundation"]
+tui = ["dep:ratatui"]
 
 # =============================================================================
 # Platform-specific dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "branch-tone"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2024"
 authors = ["Ramzi Abdoch"]
 description = "Generate unique musical tones from git branch names"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
     <strong>Hear your git context. Every repo has a voice. Every branch has a melody.</strong>
   </p>
   <p align="center">
-    <a href="https://github.com/rmzi/branch-tone/releases"><img alt="Version" src="https://img.shields.io/badge/version-0.9.0-blue?style=flat-square"></a>
+    <a href="https://github.com/rmzi/branch-tone/releases"><img alt="Version" src="https://img.shields.io/badge/version-0.12.0-blue?style=flat-square"></a>
     <a href="https://www.rust-lang.org/"><img alt="Rust" src="https://img.shields.io/badge/rust-2024_edition-orange?style=flat-square&logo=rust"></a>
     <a href="https://github.com/rmzi/branch-tone/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/badge/license-MIT-green?style=flat-square"></a>
     <a href="#"><img alt="Platform" src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey?style=flat-square"></a>
@@ -154,6 +154,53 @@ O   ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·  ·
 
 **Record mode** — press `r` to arm, then `z`/`x`/`c`/`v` to live-record kick/snare/hat/open during playback.
 
+## Terminal Dashboard (TUI)
+
+A live system monitor that visualizes everything the daemon is doing — built with [ratatui](https://github.com/ratatui/ratatui).
+
+```bash
+cargo install --path . --features tui
+branch-tone tui
+```
+
+```
+┌─ branch-tone ──────────────────────────────────────────────┐
+│ ● RUNNING  PID 1234  up 2h  3 voices  seed: shadow  1/16  │
+├─ Activity ─────────────────────────────────────────────────┤
+│ █▇▅▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▃▅█▇▅▃▂▁▁▁▁▁▁▂▅█▇▅ │
+│ ■tool ■prompt ■session ■agent         60 min │ 234 events  │
+├─ Stream ───────────────────────────────────────────────────┤
+│░ 21:58:28 TOOL    branch-tone/tui                          │
+│░ 21:58:29 TOOL    universe/issue_improvements              │
+│▒ 21:58:30 PROMPT  branch-tone/tui                          │
+│▒ 21:58:31 TOOL    universe/issue_improvements              │
+│▓ 21:58:32 TOOL    branch-tone/tui                          │
+│▓ 21:58:33 AGENT+  universe/issue_improvements              │
+│█ 21:58:34 TOOL    branch-tone/tui                          │
+│                                              28/80 [r]eset │
+├────────────────────────────────────────────────────────────┤
+│ [m]ute [d]rone [S]top [g]rid:1/16 [p]alette [q]uit        │
+└────────────────────────────────────────────────────────────┘
+```
+
+**Activity histogram** — 60-minute stacked bar chart. Each minute-column is colored by event type: tool calls (green), prompts (yellow), sessions (cyan), agents (blue). See your development rhythm at a glance.
+
+**Event stream** — Every hook event, color-coded and fading. Each repo gets a stable color from an 8-color palette, shown as a lane prefix (`█▓▒░`) that pulses when events arrive and decays over ~20 seconds. Newest events flash white, older ones fade to gray.
+
+**Seed palette** — Press `[p]` to open a centered overlay showing all 16 curated seeds with their groove parameters (swing, humanize, grid). Navigate with `j`/`k`, apply with `Enter`.
+
+| Key | Action |
+|-----|--------|
+| `m` | Toggle mute |
+| `d` | Toggle drone |
+| `s` / `S` | Start / stop daemon |
+| `g` | Cycle quantize grid |
+| `p` | Open seed palette |
+| `r` | Reset event view |
+| `q` | Quit |
+
+The TUI is feature-gated (`--features tui`) — zero impact on the default build. It's a read-only client that connects to the daemon over the existing Unix socket. See [`docs/tui-design.md`](docs/tui-design.md) for the full design document.
+
 ## How It Works
 
 Repo and branch are hashed **separately** with SHA-256, contributing independently to the final sound:
@@ -247,7 +294,9 @@ cargo build                   # Debug build
 cargo run -- main             # Run with args
 cargo run -- player           # Step sequencer
 cargo build --release         # Optimized build
-cargo test                    # 57 tests
+cargo test                    # 141 tests
+cargo build --features tui    # With terminal dashboard
+cargo build --features tray   # With macOS menu bar
 ```
 
 ## Stack
@@ -258,7 +307,7 @@ cargo test                    # 57 tests
 | Audio | [CPAL](https://github.com/RustAudio/cpal) (Cross-Platform Audio Library) |
 | Hashing | SHA-256 (two-layer: repo + branch) |
 | CLI | [Clap](https://github.com/clap-rs/clap) with derive macros |
-| Terminal | [Crossterm](https://github.com/crossterm-rs/crossterm) for the step sequencer |
+| Terminal | [Crossterm](https://github.com/crossterm-rs/crossterm) for the step sequencer, [Ratatui](https://github.com/ratatui/ratatui) for the TUI dashboard |
 | Synthesis | Saw/sine oscillators, Butterworth LPF, Schroeder reverb, BBD chorus, tape delay |
 | Scales | 10 types across 12 chromatic roots |
 

--- a/docs/jazz-ensemble.md
+++ b/docs/jazz-ensemble.md
@@ -8,16 +8,20 @@ voice signals a different aspect of the agent lifecycle.
 ```
 Voice             Hook Events                        Character
 ────────────────  ─────────────────────────────────── ──────────────────────
-Drums (kick/snr)  UserPromptSubmit, Stop              Downbeat / backbeat
-Hi-Hat (tools)    PreToolUse, PostToolUse,            Rapid micro-clicks
-                  PostToolUseFailure
+Drums (kick/snr)  UserPromptSubmit, Stop,             Downbeat / backbeat
+                  ElicitationResult
+Hi-Hat (tools)    PreToolUse, PostToolUse,            Rapid micro-clicks,
+                  PostToolUseFailure, FileChanged     tool-specific timbre
 Bass (agents)     SubagentStart, SubagentStop,        Ascending / descending
-                  WorktreeCreate, WorktreeRemove      notes (voices enter/leave)
-Keys/Pad (sess)   SessionStart, SessionEnd            Full chord bloom / fade
-Horn (attention)  PermissionRequest, Notification     Melodic phrase, look here
+                  WorktreeCreate, WorktreeRemove      notes (agent register shift)
+Keys/Pad (sess)   SessionStart, SessionEnd, Setup     Full chord bloom / fade
+Horn (attention)  PermissionRequest, Notification,    Melodic phrase, look here
+                  StopFailure, PermissionDenied,
+                  Elicitation
 Piano (lifecycle) InstructionsLoaded, ConfigChange,   Arpeggios, chord shifts,
-                  TaskCompleted, PreCompact,           resolution cadences
-                  TeammateIdle
+                  TaskCompleted, TaskCreated,          resolution cadences
+                  PreCompact, PostCompact,
+                  TeammateIdle, CwdChanged
 ```
 
 ## Event Categories
@@ -41,25 +45,82 @@ Default          1.0x    0          base    Center — fallback
 ```
 Event                Dur(ms)  Vol    Voice           Effects                      Seed
 ───────────────────  ───────  ─────  ──────────────  ───────────────────────────── ────
-SessionStart         3500     0.30   Keys/Pad        bulldozer+chorus+dub         1
-SessionEnd           3500     0.25   Keys/Pad        bulldozer+chorus+dub+reverse 4
-Stop                 400      0.12   Drums (snare)   single_hit                   3
-UserPromptSubmit     350      0.08   Drums (kick)    single_hit                   5
-PreToolUse           120      0.05   Hi-Hat (closed) single_hit                   11
-PostToolUse          150      0.05   Hi-Hat (open)   single_hit                   12
-PostToolUseFailure   250      0.08   Hi-Hat (rim)    single_hit                   13
-PermissionRequest    2500     0.18   Horn            bulldozer+chorus+dub         2
-Notification         2000     0.15   Horn            bulldozer+chorus+dub         6
-SubagentStart        1000     0.10   Bass (ascend)   pad+dub                      7
-SubagentStop         1000     0.10   Bass (descend)  pad+chorus+dub+reverse       8
-WorktreeCreate       1200     0.10   Bass (ascend)   pad+dub                      14
-WorktreeRemove       1200     0.10   Bass (descend)  pad+dub+reverse              15
-InstructionsLoaded   1500     0.10   Piano (arp)     pad+chorus+dub               16
-ConfigChange         1800     0.10   Piano (shift)   pad+tremolo+dub              17
-TaskCompleted        2500     0.15   Piano (resolve) pad+chorus+dub               18
-PreCompact           2000     0.10   Piano (sweep)   pad+chorus+dub+reverse       9
-TeammateIdle         1500     0.08   Piano (hold)    pad+chorus+dub               10
+SessionStart         3500     0.35   Keys/Pad        chorus+dub                   1
+SessionEnd           3500     0.30   Keys/Pad        chorus+dub+reverse           4
+Stop                 400      0.18   Drums (snare)   single_hit                   3
+UserPromptSubmit     350      0.12   Drums (kick)    single_hit                   5
+PreToolUse           120      0.08   Hi-Hat (closed) single_hit, tool timbre      11
+PostToolUse          150      0.08   Hi-Hat (open)   single_hit, tool timbre      12
+PostToolUseFailure   250      0.12   Hi-Hat (rim)    single_hit, error dissonance 13
+PermissionRequest    2500     0.28   Horn            chorus+dub                   2
+Notification         2000     0.22   Horn            chorus+dub                   6
+SubagentStart        1000     0.25   Bass (ascend)   dub+randomize, agent shift   7
+SubagentStop         1000     0.25   Bass (descend)  dub+reverse+randomize        8
+WorktreeCreate       1200     0.25   Bass (ascend)   dub                          14
+WorktreeRemove       1200     0.25   Bass (descend)  dub+reverse                  15
+InstructionsLoaded   1500     0.15   Piano (arp)     dub                          16
+ConfigChange         1800     0.15   Piano (shift)   dub                          17
+TaskCompleted        2500     0.22   Piano (resolve) dub                          18
+PreCompact           2000     0.15   Piano (sweep)   dub+reverse                  9
+TeammateIdle         1500     0.12   Piano (hold)    dub                          10
+StopFailure          3000     0.30   Horn (error)    dub, error dissonance        19
+PermissionDenied     1500     0.25   Horn (error)    dub, error dissonance        20
+PostCompact          2000     0.15   Piano (resolve) dub                          21
+Setup                1500     0.12   Keys/Pad        quiet opening                22
+TaskCreated          2000     0.18   Piano (ascend)  dub                          23
+CwdChanged           800      0.10   Piano (pivot)   quick                        24
+FileChanged          100      0.06   Hi-Hat (ghost)  single_hit, softest          25
+Elicitation          2000     0.22   Horn (question) dub, rising                  26
+ElicitationResult    350      0.12   Drums (answer)  single_hit                   27
 ```
+
+## Tool Timbral Mapping
+
+In the daemon, each tool type gets a unique spectral fingerprint via filter
+multiplier, detune, and harmonic flags. Every tool call stays in the repo's
+key but sounds different:
+
+```
+Tool Family        Filter   Detune  Harmonics       Character
+─────────────────  ───────  ──────  ──────────────  ────────────────────
+Read/Glob/Grep     1.4x     2¢      2nd             Bright, investigative
+Write/Edit         0.7x     1¢      fundamental     Warm, creative
+Bash               1.0x     6¢      saw boost       Aggressive, execution
+Agent              0.9x     4¢      2nd+3rd         Airy, delegation
+WebSearch/Fetch    1.3x     2¢      3rd             Distant, ethereal
+(unknown)          1.0x     0¢      none            Neutral
+```
+
+## Agent Register Mapping
+
+When bass events (SubagentStart/Stop) carry an `agent_type`, the note
+frequency is shifted to place different agents in different registers:
+
+```
+Agent Type    Shift   Register          Character
+────────────  ──────  ────────────────  ───────────────────
+researcher    0.75x   Low               Methodical scanning
+reviewer      0.875x  Low-mid           Authoritative
+documenter    0.9x    Below center      Quiet, background
+worker        1.0x    Center            Building
+auditor       1.125x  High-mid          Analytical
+validator     1.25x   High              Scrutinizing
+scout         1.5x    Highest           Quick observation
+```
+
+## Error Dissonance
+
+Events with errors (`PostToolUseFailure`, `StopFailure`, `PermissionDenied`,
+or any event carrying a non-empty `error` field) get dissonance layered on
+top of their normal sound:
+
+- **Tritone** (6 semitones up): 25% volume — the *diabolus in musica*,
+  most unstable interval in Western harmony
+- **Minor 2nd** (1 semitone up): 10% volume — tightest possible clash
+- **Pitch drop**: 15% volume — frequency descends 30% over the note's
+  duration, creating descending anxiety
+
+All three layers use exponential decay so dissonance fades quickly.
 
 ## Worktree-as-Voice
 

--- a/docs/sound-design.md
+++ b/docs/sound-design.md
@@ -7,6 +7,8 @@ jungle/liquid DnB production techniques.
 > **See also**: [Jazz Ensemble](jazz-ensemble.md) — how 18 Claude Code hook
 > events map to a jazz ensemble (drums, bass, keys, horn, piano), including
 > the PDS lifecycle mapping and worktree-as-voice concept.
+> [TUI Design](tui-design.md) — terminal dashboard architecture, rendering
+> techniques, and development diary.
 
 ## Source Material: Blu Mar Ten JungleJungle Pack
 

--- a/docs/sound-design.md
+++ b/docs/sound-design.md
@@ -4,9 +4,10 @@ Synthesis research and parameter notes for `branch-tone`'s audio engine.
 Based on Blu Mar Ten's JungleJungle (1989–1999) sample pack and broader
 jungle/liquid DnB production techniques.
 
-> **See also**: [Jazz Ensemble](jazz-ensemble.md) — how 18 Claude Code hook
+> **See also**: [Jazz Ensemble](jazz-ensemble.md) — how 27 Claude Code hook
 > events map to a jazz ensemble (drums, bass, keys, horn, piano), including
-> the PDS lifecycle mapping and worktree-as-voice concept.
+> tool timbral mapping, agent register shifts, error dissonance, the PDS
+> lifecycle mapping, and worktree-as-voice concept.
 > [TUI Design](tui-design.md) — terminal dashboard architecture, rendering
 > techniques, and development diary.
 

--- a/docs/tui-design.md
+++ b/docs/tui-design.md
@@ -53,13 +53,13 @@ means you can open and close the TUI without affecting playback.
 │ █▇▅▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▃▅█▇▅▃▂▁▁▁▁▁▁▂▅█▇▅ │
 │ ■tool ■prompt ■session ■agent         60 min │ 234 events  │
 ├─ Stream ───────────────────────────────────────────────────┤
-│░ 21:58:28 TOOL    branch-tone/tui                          │
-│░ 21:58:29 TOOL    universe/issue_improvements              │
+│░ 21:58:28 READ    branch-tone/tui [Read]                    │
+│░ 21:58:29 BASH    universe/issue_improvements [Bash]       │
 │▒ 21:58:30 PROMPT  branch-tone/tui                          │
-│▒ 21:58:31 TOOL    universe/issue_improvements              │
-│▓ 21:58:32 TOOL    branch-tone/tui                          │
-│▓ 21:58:33 AGENT+  universe/issue_improvements              │
-│█ 21:58:34 TOOL    branch-tone/tui                          │
+│▒ 21:58:31 WRITE   universe/issue_improvements [Edit]       │
+│▓ 21:58:32 READ    branch-tone/tui [Grep]                   │
+│▓ 21:58:33 AGENT+  universe/issue_improvements <worker>     │
+│█ 21:58:34 FAIL    branch-tone/tui [Bash]                   │
 │                                              28/80 [r]eset │
 ├────────────────────────────────────────────────────────────┤
 │ [m]ute [d]rone [S]top [g]rid:1/16 [p]alette [q]uit        │
@@ -140,10 +140,10 @@ for (category, buckets) in &state.activity.per_category {
 
 | Category | Color | Events |
 |----------|-------|--------|
-| Tool | Green | PreToolUse, PostToolUse, PostToolUseFailure |
-| Prompt | Yellow | UserPromptSubmit |
-| Session | Cyan | SessionStart, SessionEnd |
-| Agent | Blue | SubagentStart, SubagentStop, TaskCompleted |
+| Tool | Green | PreToolUse, PostToolUse, PostToolUseFailure, FileChanged |
+| Prompt | Yellow | UserPromptSubmit, Elicitation, ElicitationResult |
+| Session | Cyan | SessionStart, SessionEnd, Setup |
+| Agent | Blue | SubagentStart, SubagentStop, TaskCompleted, TaskCreated, TeammateIdle |
 | Other | DarkGray | Everything else |
 
 This is one of the few places where ratatui's immediate-mode buffer is
@@ -181,7 +181,39 @@ appends one line per hook invocation:
 
 ```
 2026-04-01T21:58:29 PreToolUse branch-tone tui
+2026-04-01T21:58:30 PreToolUse branch-tone tui	Read	
+2026-04-01T21:58:31 SubagentStart branch-tone feat		worker
 ```
+
+The format is backward-compatible: 4 space-delimited fields (`timestamp
+event repo branch`), with optional tab-delimited enrichment after the branch
+(`\ttool_name\tagent_type`). Old parsers see `"branch\ttool\tagent"` as
+the branch field (harmless); new parsers split on tab to extract tool and
+agent context.
+
+### Tool & Agent Badges
+
+When enrichment is present, the Stream panel appends colored badges:
+
+- **Tool badges** `[Read]` `[Bash]` `[Edit]` — color-coded by tool family
+  (Cyan for reads, Yellow for writes, Red for Bash, Blue for Agent, Magenta
+  for web tools)
+- **Agent badges** `<worker>` `<researcher>` — Blue, showing which agent
+  type spawned
+
+### Tool-Aware Labels
+
+ToolPulse events (PreToolUse/PostToolUse) show tool-specific labels instead
+of generic `TOOL`:
+
+| Tool | Label |
+|------|-------|
+| Read, Glob, Grep | `READ` |
+| Write, Edit | `WRITE` |
+| Bash | `BASH` |
+| Agent | `AGENT` |
+| WebSearch, WebFetch | `WEB` |
+| (other) | `TOOL` |
 
 The TUI reads the last 500 lines for the activity histogram and displays
 the most recent 80 in the Stream panel. Press `[r]` to reset the view
@@ -259,3 +291,36 @@ Redesigned from the ground up:
 - Moved seeds to a **popup overlay** ([p] to open, Esc to close)
 - Added **[r]eset** to clear the view and start fresh
 - 155 tests total with TUI feature
+
+### Session 2: Deep Hook Integration (2026-04-02)
+
+**Goal**: Extract and surface the 30+ fields in Claude Code hook JSON that
+were being thrown away. Each tool type should sound different, each agent
+type should occupy a different register, and errors should sound dissonant.
+
+**6 work streams** across extraction → protocol → dispatch → synthesis:
+
+1. **HookContext struct** — extracts `tool_name`, `agent_type`, `error_msg`,
+   `session_id` from hook JSON. All fields default to "" for backward compat.
+
+2. **27 events** — expanded from 18. Added `StopFailure`, `PermissionDenied`,
+   `PostCompact`, `Setup`, `TaskCreated`, `CwdChanged`, `FileChanged`,
+   `Elicitation`, `ElicitationResult`. Each with unique seed (19–27).
+
+3. **Socket protocol** — `send_to_daemon` now serializes all HookContext
+   fields. Daemon extracts `tool_name`, `agent_type`, `error` with backward
+   compat for old clients.
+
+4. **TUI enrichment** — ParsedEvent parses tab-delimited enrichment from
+   logs. Stream shows `[Read]` tool badges and `<worker>` agent badges.
+   Tool-aware labels: `READ`, `WRITE`, `BASH` instead of generic `TOOL`.
+
+5. **Dispatch wiring** — QueuedNote carries `tool_filter`, `tool_detune`,
+   `tool_harmonics`, `is_error`. VoiceSlot gets matching atomics. Agent
+   octave shift applied to bass event frequencies.
+
+6. **Audio synthesis** — ToolPulse branch reads new atomics: applies filter
+   multiplier, detuned second voice, conditional harmonics/saw boost per
+   tool type. Error dissonance: tritone + minor 2nd + pitch drop.
+
+**Result**: 169 tests (22 new), zero new warnings, all build targets pass

--- a/docs/tui-design.md
+++ b/docs/tui-design.md
@@ -1,0 +1,261 @@
+# TUI Design: Terminal Dashboard
+
+How branch-tone's terminal dashboard visualizes the daemon as a live system
+monitor — architecture, rendering techniques, and design decisions.
+
+> **See also**: [Sound Design](sound-design.md) — synthesis engine details.
+> [Jazz Ensemble](jazz-ensemble.md) — event-to-voice mapping.
+
+## Motivation
+
+branch-tone runs as a daemon receiving hook events from Claude Code sessions.
+The tray app (macOS) shows status in the menu bar, but offers no sense of
+*flow* — you can't feel the rhythm of your development sessions. The TUI
+exists to make the entire system visible: every event, every voice, every
+heartbeat.
+
+## Architecture
+
+```
+┌───────────────────────────────────────────────────────┐
+│  Claude Code sessions (1–5 workstreams)               │
+│  ├── branch-tone hook (stdin JSON)                    │
+│  └── writes to ~/.branch-tone/events.log              │
+│       sends to daemon via Unix socket                 │
+└───────────────┬───────────────────────────────────────┘
+                │
+    ┌───────────▼───────────────────────────┐
+    │  branch-tone daemon                    │
+    │  ├── 8 voice slots (cpal audio)        │
+    │  ├── Unix socket (__status_json)       │
+    │  └── state files (seed, mute, etc.)    │
+    └───────────┬───────────────────────────┘
+                │ polls every 2s
+    ┌───────────▼───────────────────────────┐
+    │  branch-tone tui (this)               │
+    │  ├── ratatui + crossterm              │
+    │  ├── read-only client (no audio)      │
+    │  └── ~5fps render, 200ms input poll   │
+    └───────────────────────────────────────┘
+```
+
+The TUI is a **pure observer** — it never touches the audio engine. It
+connects to the daemon the same way the tray app does: polling `__status_json`
+over the Unix socket and reading state files from `~/.branch-tone/`. This
+means you can open and close the TUI without affecting playback.
+
+## Layout
+
+```
+┌─ branch-tone ──────────────────────────────────────────────┐
+│ ● RUNNING  PID 1234  up 2h  3 voices  seed: shadow  1/16  │
+├─ Activity ─────────────────────────────────────────────────┤
+│ █▇▅▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▃▅█▇▅▃▂▁▁▁▁▁▁▂▅█▇▅ │
+│ ■tool ■prompt ■session ■agent         60 min │ 234 events  │
+├─ Stream ───────────────────────────────────────────────────┤
+│░ 21:58:28 TOOL    branch-tone/tui                          │
+│░ 21:58:29 TOOL    universe/issue_improvements              │
+│▒ 21:58:30 PROMPT  branch-tone/tui                          │
+│▒ 21:58:31 TOOL    universe/issue_improvements              │
+│▓ 21:58:32 TOOL    branch-tone/tui                          │
+│▓ 21:58:33 AGENT+  universe/issue_improvements              │
+│█ 21:58:34 TOOL    branch-tone/tui                          │
+│                                              28/80 [r]eset │
+├────────────────────────────────────────────────────────────┤
+│ [m]ute [d]rone [S]top [g]rid:1/16 [p]alette [q]uit        │
+└────────────────────────────────────────────────────────────┘
+```
+
+Four vertical zones:
+
+| Zone | Height | Purpose |
+|------|--------|---------|
+| **Status bar** | 3 rows | Daemon state, voice count, seed, grid, mute |
+| **Activity** | 5 rows | 60-minute stacked histogram by event category |
+| **Stream** | Remaining | Unified voice+event feed with colored lanes |
+| **Footer** | 1 row | Keybind hints |
+
+### Design Decision: No Separate Voice Panel
+
+Earlier iterations had a split layout: voices on the left, seeds on the right,
+events at the bottom. The user's feedback was clear: "I'll never run more than
+5 workstreams — give me more events." The redesign merged voices into the event
+stream via colored lane prefixes, and moved seeds to a popup overlay.
+
+## Rendering Techniques
+
+### Voice Lane Colors
+
+Each active voice slot gets a stable color from an 8-color palette:
+
+```rust
+const VOICE_COLORS: [Color; 8] = [
+    Cyan, Green, Yellow, Magenta, Blue, Red, LightCyan, LightGreen,
+];
+```
+
+Every event line starts with a colored block character (`█▓▒░`) matching its
+repo's voice slot. This creates a visual "lane" effect where you can track
+activity per workstream without explicit headers. The color assignment is
+positional (slot 0 = Cyan, slot 1 = Green), so it's stable as long as the
+voice remains active.
+
+### Recency Gradient
+
+Events don't have a binary "new/old" state. Instead, each line's brightness
+is computed from its position in the visible list:
+
+```
+recency = line_index / visible_count    (0.0 = oldest, 1.0 = newest)
+```
+
+| Recency | Time color | Type color | Repo color |
+|---------|------------|------------|------------|
+| > 0.8 | DarkGray | Full type color | Voice color |
+| > 0.5 | DarkGray | DarkGray | Voice color |
+| < 0.5 | DarkGray | DarkGray | DarkGray |
+| Newest + flash | **White** | **White + Bold** | **White** |
+
+The newest event also gets a 2-second "flash" where the entire Stream border
+turns Green and the line renders in White+Bold. This creates a waterfall
+effect: events light up bright at the bottom and dim as they scroll up.
+
+### Activity Histogram (Stacked Per-Category)
+
+The Activity panel renders a 60-column bar chart where each column = 1 minute.
+Bars are **stacked by event type category**, drawn bottom-up with direct
+buffer writes:
+
+```rust
+for (category, buckets) in &state.activity.per_category {
+    // Scale value to available column height
+    let bar_h = (val * col_height) / max_val;
+    // Draw colored block characters bottom-up
+    for _ in 0..bar_h {
+        buffer[(x, y)].set_char('█').set_fg(category.color());
+        y -= 1;
+    }
+}
+```
+
+| Category | Color | Events |
+|----------|-------|--------|
+| Tool | Green | PreToolUse, PostToolUse, PostToolUseFailure |
+| Prompt | Yellow | UserPromptSubmit |
+| Session | Cyan | SessionStart, SessionEnd |
+| Agent | Blue | SubagentStart, SubagentStop, TaskCompleted |
+| Other | DarkGray | Everything else |
+
+This is one of the few places where ratatui's immediate-mode buffer is
+accessed directly rather than through widgets — the `Sparkline` widget only
+supports single-color bars, so stacked coloring requires cell-level control.
+
+### Seed Overlay
+
+The seed picker is a modal popup rendered on top of the main view:
+
+1. Compute centered `Rect` (50 wide, 20 tall, clamped to terminal size)
+2. Render `ratatui::widgets::Clear` to erase the background cells
+3. Render the seed `List` widget with `ListState` for selection tracking
+
+The overlay captures all keyboard input while open (j/k navigate, Enter
+applies, Esc/p closes). This pattern avoids the complexity of focus
+management — there are only two states: overlay open or closed.
+
+### Voice Activity Decay
+
+Each repo's last-event time is tracked. The lane prefix character decays
+through block densities over ~20 seconds:
+
+| Age | Char | Color |
+|-----|------|-------|
+| < 1s | `█` | White (flash) |
+| < 2s | `▓` | Voice color |
+| < 10s (recency > 0.7) | `▒` | Voice color |
+| Older | `░` | Voice color |
+
+## Event Lifecycle
+
+Events persist in `~/.branch-tone/events.log` indefinitely — the daemon
+appends one line per hook invocation:
+
+```
+2026-04-01T21:58:29 PreToolUse branch-tone tui
+```
+
+The TUI reads the last 500 lines for the activity histogram and displays
+the most recent 80 in the Stream panel. Press `[r]` to reset the view
+(clears displayed events and voice activity, starts counting from zero).
+
+## Controls
+
+| Key | Action | Scope |
+|-----|--------|-------|
+| `m` | Toggle mute (all audio) | File: `~/.branch-tone/mute` |
+| `d` | Toggle drone (ambient bed) | File: `~/.branch-tone/no-drone` |
+| `s` | Start daemon | Spawns `branch-tone daemon --detach` |
+| `S` | Stop daemon | Sends `__shutdown` via socket |
+| `g` | Cycle quantize grid | File: `~/.branch-tone/quantize` (auto→32→16→8→4) |
+| `p` | Open seed palette | Overlay panel |
+| `r` | Reset event view | Clears display, restarts counting |
+| `q` / Esc | Quit | (Esc also closes seed overlay) |
+| `j`/`k` | Navigate seeds | Only when overlay open |
+| Enter | Apply selected seed | Only when overlay open |
+| `x` | Clear seed | Only when overlay open |
+
+## Feature Gating
+
+The TUI is behind `--features tui` to keep the default binary lean:
+
+```toml
+[dependencies]
+ratatui = { version = "0.29", optional = true, features = ["crossterm"] }
+
+[features]
+tui = ["dep:ratatui"]
+```
+
+ratatui brings ~25 transitive dependencies (cassowary, compact_str, itertools,
+lru, etc.) that are only compiled when opted in. The hook binary — which fires
+on every Claude Code event — stays fast and small.
+
+Unlike the tray feature (`cfg(target_os = "macos")`), the TUI has no platform
+gate. ratatui + crossterm is cross-platform, so `branch-tone tui` works on
+macOS, Linux, and Windows.
+
+## Development Diary
+
+### Session 1: Initial Implementation (2026-04-01)
+
+**Research phase** — surveyed the musical TUI landscape:
+- **textStep** (Rust/ratatui): Full step sequencer + drum machine at 60fps.
+  Proved the pattern works. Two-thread architecture: UI + audio over lock-free
+  channels.
+- **scope-tui**: Terminal oscilloscope using braille characters.
+- **cava**: The gold standard terminal audio visualizer (C).
+
+**Key decision**: branch-tone's TUI should be a **pure client**, not embed
+audio. The daemon already owns the audio thread. The TUI connects over the
+existing Unix socket — same protocol the tray app uses. No cpal, no audio
+thread, no lock-free channels needed.
+
+**v1 — Basic dashboard**: Status bar, voice table, seed list, event log,
+keybind footer. Split layout (voices left, seeds right). Feature-gated behind
+`--features tui`. 7 new tests.
+
+**v2 — Color and activity**: Parsed event log lines with per-type colors
+(TOOL=green, START=cyan, PROMPT=yellow, FAIL=red). Added 60-minute activity
+sparkline. Voice slots pulse with block-density decay (██→▓▓→▒▒→░░). Event
+border flashes green on new arrivals. Recency gradient fades older events.
+
+**v3 — Unified stream**: User feedback: "I'll never run more than 5
+workstreams. Make the events bigger. Make things light up."
+
+Redesigned from the ground up:
+- Merged voices + events into a single **Stream** panel with colored lane
+  prefixes (stable per-repo colors from an 8-color palette)
+- Replaced the single-color sparkline with **stacked per-category bars**
+  using direct buffer writes for cell-level color control
+- Moved seeds to a **popup overlay** ([p] to open, Esc to close)
+- Added **[r]eset** to clear the view and start fresh
+- 155 tests total with TUI feature

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -25,7 +25,16 @@
     "ConfigChange": [{ "hooks": [{ "type": "command", "command": "branch-tone hook", "async": true }] }],
     "TaskCompleted": [{ "hooks": [{ "type": "command", "command": "branch-tone hook", "async": true }] }],
     "WorktreeCreate": [{ "hooks": [{ "type": "command", "command": "branch-tone hook", "async": true }] }],
-    "WorktreeRemove": [{ "hooks": [{ "type": "command", "command": "branch-tone hook", "async": true }] }]
+    "WorktreeRemove": [{ "hooks": [{ "type": "command", "command": "branch-tone hook", "async": true }] }],
+    "StopFailure": [{ "hooks": [{ "type": "command", "command": "branch-tone hook", "async": true }] }],
+    "PermissionDenied": [{ "hooks": [{ "type": "command", "command": "branch-tone hook", "async": true }] }],
+    "PostCompact": [{ "hooks": [{ "type": "command", "command": "branch-tone hook", "async": true }] }],
+    "Setup": [{ "hooks": [{ "type": "command", "command": "branch-tone hook", "async": true }] }],
+    "TaskCreated": [{ "hooks": [{ "type": "command", "command": "branch-tone hook", "async": true }] }],
+    "CwdChanged": [{ "hooks": [{ "type": "command", "command": "branch-tone hook", "async": true }] }],
+    "FileChanged": [{ "hooks": [{ "type": "command", "command": "branch-tone hook", "async": true }] }],
+    "Elicitation": [{ "hooks": [{ "type": "command", "command": "branch-tone hook", "async": true }] }],
+    "ElicitationResult": [{ "hooks": [{ "type": "command", "command": "branch-tone hook", "async": true }] }]
   },
   "settings": {
     "permissions": { "allow": ["Bash(branch-tone*)"] },

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -9,6 +9,23 @@
     "SubagentStart": [{ "hooks": [{ "type": "command", "command": "branch-tone hook", "async": true }] }],
     "SubagentStop": [{ "hooks": [{ "type": "command", "command": "branch-tone hook", "async": true }] }],
     "PreCompact": [{ "hooks": [{ "type": "command", "command": "branch-tone hook", "async": true }] }],
-    "TeammateIdle": [{ "hooks": [{ "type": "command", "command": "branch-tone hook", "async": true }] }]
+    "TeammateIdle": [{ "hooks": [{ "type": "command", "command": "branch-tone hook", "async": true }] }],
+    "PreToolUse": [{ "hooks": [{ "type": "command", "command": "branch-tone hook", "async": true }] }],
+    "PostToolUse": [{ "hooks": [{ "type": "command", "command": "branch-tone hook", "async": true }] }],
+    "PostToolUseFailure": [{ "hooks": [{ "type": "command", "command": "branch-tone hook", "async": true }] }],
+    "InstructionsLoaded": [{ "hooks": [{ "type": "command", "command": "branch-tone hook", "async": true }] }],
+    "ConfigChange": [{ "hooks": [{ "type": "command", "command": "branch-tone hook", "async": true }] }],
+    "TaskCompleted": [{ "hooks": [{ "type": "command", "command": "branch-tone hook", "async": true }] }],
+    "WorktreeCreate": [{ "hooks": [{ "type": "command", "command": "branch-tone hook", "async": true }] }],
+    "WorktreeRemove": [{ "hooks": [{ "type": "command", "command": "branch-tone hook", "async": true }] }],
+    "StopFailure": [{ "hooks": [{ "type": "command", "command": "branch-tone hook", "async": true }] }],
+    "PermissionDenied": [{ "hooks": [{ "type": "command", "command": "branch-tone hook", "async": true }] }],
+    "PostCompact": [{ "hooks": [{ "type": "command", "command": "branch-tone hook", "async": true }] }],
+    "Setup": [{ "hooks": [{ "type": "command", "command": "branch-tone hook", "async": true }] }],
+    "TaskCreated": [{ "hooks": [{ "type": "command", "command": "branch-tone hook", "async": true }] }],
+    "CwdChanged": [{ "hooks": [{ "type": "command", "command": "branch-tone hook", "async": true }] }],
+    "FileChanged": [{ "hooks": [{ "type": "command", "command": "branch-tone hook", "async": true }] }],
+    "Elicitation": [{ "hooks": [{ "type": "command", "command": "branch-tone hook", "async": true }] }],
+    "ElicitationResult": [{ "hooks": [{ "type": "command", "command": "branch-tone hook", "async": true }] }]
   }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -272,14 +272,39 @@ const OCTAVES: [f32; 5] = [0.5, 0.75, 1.0, 1.5, 2.0];
 const MODE_NAMES: [&str; 5] = ["Arpeggio", "Chorus Arp", "Pad", "Bulldozer", "Tremolo Arp"];
 
 /// All Claude Code hook events we register and handle
-const HOOK_EVENTS: [&str; 18] = [
+const HOOK_EVENTS: [&str; 27] = [
     "SessionStart", "SessionEnd", "Stop", "UserPromptSubmit",
     "PermissionRequest", "Notification",
     "SubagentStart", "SubagentStop", "PreCompact", "TeammateIdle",
     "PreToolUse", "PostToolUse", "PostToolUseFailure",
     "InstructionsLoaded", "ConfigChange", "TaskCompleted",
     "WorktreeCreate", "WorktreeRemove",
+    "StopFailure", "PermissionDenied", "PostCompact", "Setup",
+    "TaskCreated", "CwdChanged", "FileChanged",
+    "Elicitation", "ElicitationResult",
 ];
+
+/// Enriched context extracted from Claude Code hook JSON payloads.
+/// All fields default to "" when absent (backward compat with older Claude Code versions).
+struct HookContext {
+    event: String,
+    repo: String,
+    branch: String,
+    tool_name: String,
+    agent_type: String,
+    error_msg: String,
+    session_id: String,
+}
+
+impl Default for HookContext {
+    fn default() -> Self {
+        Self {
+            event: String::new(), repo: String::new(), branch: String::new(),
+            tool_name: String::new(), agent_type: String::new(),
+            error_msg: String::new(), session_id: String::new(),
+        }
+    }
+}
 
 /// Arpeggio patterns - 3 note (intervals from root in scale degrees)
 const PATTERNS_3: [[i32; 3]; 8] = [
@@ -2180,11 +2205,67 @@ fn hook_play_args(event: &str, repo: String, branch: String, spooky: bool) -> Pl
             EventCategory::Lifecycle, 10,
         ),
 
+        // ── Error/Attention ────────────────────────────────────────
+        "StopFailure" => tonal(
+            repo, branch, spooky, mode_effects, mode_steps,
+            3000, 0.30, 5, true, false, false,
+            EventCategory::Attention, 19,
+        ),
+        "PermissionDenied" => tonal(
+            repo, branch, spooky, mode_effects, mode_steps,
+            1500, 0.25, 3, true, false, false,
+            EventCategory::Attention, 20,
+        ),
+        "PostCompact" => tonal(
+            repo, branch, spooky, mode_effects, mode_steps,
+            2000, 0.15, 3, true, false, false,
+            EventCategory::Lifecycle, 21,
+        ),
+        "Setup" => tonal(
+            repo, branch, spooky, mode_effects, mode_steps,
+            1500, 0.12, 3, false, false, false,
+            EventCategory::SessionBoundary, 22,
+        ),
+        "TaskCreated" => tonal(
+            repo, branch, spooky, mode_effects, mode_steps,
+            2000, 0.18, 3, true, false, false,
+            EventCategory::Lifecycle, 23,
+        ),
+        "CwdChanged" => tonal(
+            repo, branch, spooky, mode_effects, mode_steps,
+            800, 0.10, 3, false, false, false,
+            EventCategory::Lifecycle, 24,
+        ),
+        "FileChanged" => PlayArgs {
+            branch: Some(branch), repo: Some(repo),
+            duration: 100, volume: 0.06,
+            pad: false, chorus: false, tremolo: false, bulldozer: false,
+            steps: 1, spooky, reverse: false, randomize: false,
+            drums: false, dub_delay: false, melody_over_drums: false,
+            single_hit: true, event_category: EventCategory::ToolPulse,
+            event_seed: 25,
+            break_pattern: None, dry_run: false, quiet: true, event_density: 0,
+        },
+        "Elicitation" => tonal(
+            repo, branch, spooky, mode_effects, mode_steps,
+            2000, 0.22, 3, true, false, false,
+            EventCategory::Attention, 26,
+        ),
+        "ElicitationResult" => PlayArgs {
+            branch: Some(branch), repo: Some(repo),
+            duration: 350, volume: 0.12,
+            pad: false, chorus: false, tremolo: false, bulldozer: false,
+            steps: 1, spooky, reverse: false, randomize: false,
+            drums: false, dub_delay: false, melody_over_drums: false,
+            single_hit: true, event_category: EventCategory::DrumHit,
+            event_seed: 27,
+            break_pattern: None, dry_run: false, quiet: true, event_density: 0,
+        },
+
         // ── Unknown events ─────────────────────────────────────────
         _ => tonal(
             repo, branch, spooky, mode_effects, mode_steps,
-            300, 0.18, 3,
-            false, false, false,
+            300, 0.18, 3, false, false, false,
             EventCategory::Default, 0,
         ),
     }
@@ -2209,6 +2290,10 @@ struct QueuedNote {
     volume: f32,
     duration_ms: u32,
     note_freq: f32,     // pitched percussion frequency (from scale)
+    tool_filter: f32,   // filter cutoff multiplier (1.0 = neutral)
+    tool_detune: f32,   // extra detune in cents
+    tool_harmonics: u8, // bit flags: b0=2nd harmonic, b1=3rd, b2=saw boost
+    is_error: bool,     // true = apply dissonance (tritone + minor 2nd)
 }
 
 struct VoiceSlot {
@@ -2244,6 +2329,11 @@ struct VoiceSlot {
     oneshot_note_freq: std::sync::atomic::AtomicU32,
     // Precomputed grid step in samples (for queue drain timing)
     grid_step_samples: std::sync::atomic::AtomicU32,
+    // Tool-aware synthesis params (set per note from QueuedNote)
+    oneshot_tool_filter: std::sync::atomic::AtomicU32,    // f32 bits: filter cutoff multiplier
+    oneshot_tool_detune: std::sync::atomic::AtomicU32,    // f32 bits: extra detune in cents
+    oneshot_tool_harmonics: AtomicU8,                     // bit flags
+    oneshot_error_flag: AtomicBool,                       // true = apply dissonance
 }
 
 impl VoiceSlot {
@@ -2271,6 +2361,10 @@ impl VoiceSlot {
             note_counter: AtomicU8::new(0),
             oneshot_note_freq: std::sync::atomic::AtomicU32::new(0),
             grid_step_samples: std::sync::atomic::AtomicU32::new(0),
+            oneshot_tool_filter: std::sync::atomic::AtomicU32::new(f32::to_bits(1.0)),
+            oneshot_tool_detune: std::sync::atomic::AtomicU32::new(f32::to_bits(0.0)),
+            oneshot_tool_harmonics: AtomicU8::new(0),
+            oneshot_error_flag: AtomicBool::new(false),
         }
     }
 }
@@ -2422,6 +2516,34 @@ fn u8_to_category(v: u8) -> EventCategory {
 
 /// Conductor: choose a harmonically compatible interval for ambient bed transposition.
 /// Given active root frequencies, transpose new_root to prefer unisons, fifths, fourths.
+/// Tool-specific timbral parameters for synthesis differentiation.
+/// Returns (filter_mult, detune_cents, harmonics_flags).
+/// harmonics_flags: bit0=2nd harmonic, bit1=3rd harmonic, bit2=saw boost
+fn tool_timbral_params(tool_name: &str) -> (f32, f32, u8) {
+    match tool_name {
+        "Read" | "Glob" | "Grep" => (1.4, 2.0, 0b001),   // bright, investigative
+        "Write" | "Edit"         => (0.7, 1.0, 0b000),    // warm, creative
+        "Bash"                   => (1.0, 6.0, 0b100),    // aggressive, saw boost
+        "Agent"                  => (0.9, 4.0, 0b011),    // airy, 2nd+3rd harmonics
+        "WebSearch" | "WebFetch" => (1.3, 2.0, 0b010),    // distant, 3rd harmonic
+        _                        => (1.0, 0.0, 0b000),    // neutral
+    }
+}
+
+/// Agent-type octave shift for register separation in bass events.
+fn agent_octave_shift(agent_type: &str) -> f32 {
+    match agent_type {
+        "researcher"  => 0.75,
+        "worker"      => 1.0,
+        "validator"   => 1.25,
+        "reviewer"    => 0.875,
+        "scout"       => 1.5,
+        "documenter"  => 0.9,
+        "auditor"     => 1.125,
+        _             => 1.0,
+    }
+}
+
 fn conductor_transpose(new_root: f32, active_roots: &[f32]) -> f32 {
     if active_roots.is_empty() {
         return new_root;
@@ -2460,12 +2582,11 @@ fn conductor_transpose(new_root: f32, active_roots: &[f32]) -> f32 {
 
 /// Try to send an event to the running daemon via Unix socket.
 /// Returns Ok(()) if the daemon handled it, Err if no daemon or send failed.
-fn send_to_daemon(event: &str, repo: &str, branch: &str) -> Result<()> {
+fn send_to_daemon(ctx: &HookContext) -> Result<()> {
     use std::os::unix::net::UnixStream;
     use std::io::Write;
 
     let sock_path = daemon_socket_path();
-    // 50ms connect timeout for imperceptible fallback
     let stream = UnixStream::connect(&sock_path)
         .map_err(|e| anyhow::anyhow!("daemon connect: {}", e))?;
     stream.set_write_timeout(Some(Duration::from_millis(50)))
@@ -2473,12 +2594,20 @@ fn send_to_daemon(event: &str, repo: &str, branch: &str) -> Result<()> {
     stream.set_read_timeout(Some(Duration::from_millis(100)))
         .map_err(|e| anyhow::anyhow!("set timeout: {}", e))?;
 
-    let msg = format!("{{\"event\":\"{}\",\"repo\":\"{}\",\"branch\":\"{}\"}}\n", event, repo, branch);
+    let json = serde_json::json!({
+        "event": ctx.event,
+        "repo": ctx.repo,
+        "branch": ctx.branch,
+        "tool_name": ctx.tool_name,
+        "agent_type": ctx.agent_type,
+        "error": ctx.error_msg,
+        "session_id": ctx.session_id,
+    });
+    let msg = format!("{}\n", json);
     let mut stream = stream;
     stream.write_all(msg.as_bytes())
         .map_err(|e| anyhow::anyhow!("daemon write: {}", e))?;
 
-    // Read ACK
     let mut buf = [0u8; 32];
     use std::io::Read as StdRead;
     let _ = stream.read(&mut buf);
@@ -2931,6 +3060,11 @@ fn handle_daemon_connection(stream: std::os::unix::net::UnixStream, state: &Daem
         let repo = json.get("repo").and_then(|v| v.as_str()).unwrap_or("unknown");
         let branch = json.get("branch").and_then(|v| v.as_str()).unwrap_or("main");
 
+        // Extract enriched context (backward compat: old clients send only event/repo/branch)
+        let tool_name = json.get("tool_name").and_then(|v| v.as_str()).unwrap_or("");
+        let agent_type = json.get("agent_type").and_then(|v| v.as_str()).unwrap_or("");
+        let error_msg = json.get("error").and_then(|v| v.as_str()).unwrap_or("");
+
         // Update activity timestamp
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -2940,6 +3074,14 @@ fn handle_daemon_connection(stream: std::os::unix::net::UnixStream, state: &Daem
 
         // Get play args for this event
         let args = hook_play_args(event, repo.to_string(), branch.to_string(), false);
+
+        // Compute tool timbral params and error flag for synthesis
+        let (tool_filter, tool_detune, tool_harmonics) = tool_timbral_params(tool_name);
+        let is_error = !error_msg.is_empty()
+            || event == "PostToolUseFailure"
+            || event == "StopFailure"
+            || event == "PermissionDenied";
+        let agent_shift = agent_octave_shift(agent_type);
 
         // Find or allocate voice slot
         if let Some(slot_idx) = state.find_or_alloc_slot(repo, branch) {
@@ -3009,13 +3151,13 @@ fn handle_daemon_connection(stream: std::os::unix::net::UnixStream, state: &Daem
                     }
 
                     if let Ok(mut q) = slot.note_queue.lock() {
-                        // Cap queue depth to avoid unbounded growth (16 notes max)
                         if q.len() < 16 {
                             q.push_back(QueuedNote {
                                 category: category_to_u8(cat),
                                 volume: args.volume,
                                 duration_ms: args.duration as u32,
                                 note_freq,
+                                tool_filter, tool_detune, tool_harmonics, is_error,
                             });
                         }
                     }
@@ -3047,13 +3189,14 @@ fn handle_daemon_connection(stream: std::os::unix::net::UnixStream, state: &Daem
                         if let Ok(mut q) = slot.note_queue.lock() {
                             for _ni in 0..n_notes.min(notes.len()) {
                                 let idx = slot.note_counter.fetch_add(1, Relaxed) as usize;
-                                let freq = notes[idx % notes.len()];
+                                let freq = notes[idx % notes.len()] * agent_shift;
                                 if q.len() < 16 {
                                     q.push_back(QueuedNote {
                                         category: category_to_u8(cat),
                                         volume: args.volume,
                                         duration_ms: per_note_ms.max(150),
                                         note_freq: freq,
+                                        tool_filter, tool_detune, tool_harmonics, is_error,
                                     });
                                 }
                             }
@@ -3228,6 +3371,11 @@ fn daemon_audio_engine(state: Arc<DaemonState>) -> Result<()> {
                                 slot.oneshot_duration_ms.store(note.duration_ms, Relaxed);
                                 slot.oneshot_volume.store(note.volume.to_bits(), Relaxed);
                                 slot.oneshot_note_freq.store(note.note_freq.to_bits(), Relaxed);
+                                // Copy tool-aware synthesis params to slot atomics
+                                slot.oneshot_tool_filter.store(note.tool_filter.to_bits(), Relaxed);
+                                slot.oneshot_tool_detune.store(note.tool_detune.to_bits(), Relaxed);
+                                slot.oneshot_tool_harmonics.store(note.tool_harmonics, Relaxed);
+                                slot.oneshot_error_flag.store(note.is_error, Relaxed);
                                 oneshot_active[i] = true;
                                 oneshot_start_sample[i] = global;
                                 // Schedule next drain at grid boundary
@@ -3257,28 +3405,46 @@ fn daemon_audio_engine(state: Arc<DaemonState>) -> Result<()> {
                                 1.0
                             };
 
-                            // Generate one-shot sound based on category
+                            // Read tool-aware synthesis params from slot atomics
+                            let t_filter = f32::from_bits(slot.oneshot_tool_filter.load(Relaxed));
+                            let t_detune = f32::from_bits(slot.oneshot_tool_detune.load(Relaxed));
+                            let t_harmonics = slot.oneshot_tool_harmonics.load(Relaxed);
+                            let t_error = slot.oneshot_error_flag.load(Relaxed);
+
                             let cat = u8_to_category(slot.oneshot_category.load(Relaxed));
                             let oneshot_out = if let Ok(voice_guard) = slot.voice_data.lock() {
                                 if let Some(ref voice) = *voice_guard {
                                     match cat {
                                         EventCategory::ToolPulse => {
-                                            // Pitched percussion: kalimba note from scale
                                             let freq = f32::from_bits(slot.oneshot_note_freq.load(Relaxed));
-                                            let pitched = generate_pitched_hit(time, if freq > 0.0 { freq } else { voice.root_freq });
-                                            // Light drum ghost underneath (10%) for texture
+                                            let base_freq = if freq > 0.0 { freq } else { voice.root_freq };
+                                            let pitched = generate_pitched_hit(time, base_freq) * t_filter;
+                                            let detune_voice = if t_detune > 0.1 {
+                                                let ratio = (2.0f32).powf(t_detune / 1200.0);
+                                                generate_pitched_hit(time, base_freq * ratio) * 0.3
+                                            } else { 0.0 };
+                                            let h2 = if t_harmonics & 0b001 != 0 {
+                                                (2.0 * PI * base_freq * 2.0 * time).sin() * 0.15 * (-12.0 * time).exp()
+                                            } else { 0.0 };
+                                            let h3 = if t_harmonics & 0b010 != 0 {
+                                                (2.0 * PI * base_freq * 3.0 * time).sin() * 0.08 * (-15.0 * time).exp()
+                                            } else { 0.0 };
+                                            let saw = if t_harmonics & 0b100 != 0 {
+                                                let phase = base_freq * time;
+                                                let mut s = 0.0f32;
+                                                for k in 1..=6 { s += (2.0 * PI * phase * k as f32).sin() / k as f32; }
+                                                s * 0.12 * (-10.0 * time).exp()
+                                            } else { 0.0 };
                                             let drum = generate_single_hit(time, sample_rate, voice) * 0.1;
-                                            pitched + drum
+                                            pitched + detune_voice + h2 + h3 + saw + drum
                                         }
                                         EventCategory::DrumHit => {
-                                            // Kick/snare with pitched note layered on top (30%)
                                             let freq = f32::from_bits(slot.oneshot_note_freq.load(Relaxed));
                                             let drum = generate_single_hit(time, sample_rate, voice);
                                             let pitched = generate_pitched_hit(time, if freq > 0.0 { freq } else { voice.root_freq }) * 0.3;
                                             drum + pitched
                                         }
                                         _ => {
-                                            // Tonal: use full category-aware oscillator
                                             let chorus = slot.oneshot_chorus.load(Relaxed);
                                             if let Ok(notes) = slot.notes.lock() {
                                                 if let Ok(melody_guard) = slot.melody_data.lock() {
@@ -3294,14 +3460,11 @@ fn daemon_audio_engine(state: Arc<DaemonState>) -> Result<()> {
                                                                         freq, time, chorus, ni, voice, mel, tim, cat,
                                                                     ) / n_voices as f32;
                                                                 }
-                                                                // Envelope: smooth attack/release
                                                                 let env = if progress < 0.05 {
                                                                     (progress / 0.05).sqrt()
                                                                 } else if progress > 0.75 {
                                                                     ((1.0 - progress) / 0.25).sqrt()
-                                                                } else {
-                                                                    1.0
-                                                                };
+                                                                } else { 1.0 };
                                                                 sum * env
                                                             } else { 0.0 }
                                                         } else { 0.0 }
@@ -3310,14 +3473,23 @@ fn daemon_audio_engine(state: Arc<DaemonState>) -> Result<()> {
                                             } else { 0.0 }
                                         }
                                     }
-                                } else {
-                                    0.0
-                                }
-                            } else {
-                                0.0
-                            };
+                                } else { 0.0 }
+                            } else { 0.0 };
 
-                            let raw = oneshot_out * vol * global_fade;
+                            // Error dissonance: tritone + minor 2nd + pitch drop
+                            let error_layer = if t_error {
+                                let freq = f32::from_bits(slot.oneshot_note_freq.load(Relaxed));
+                                let base = if freq > 0.0 { freq } else { 440.0 };
+                                let tritone = (2.0 * PI * base * (2.0f32).powf(6.0 / 12.0) * time).sin()
+                                    * 0.25 * (-8.0 * time).exp();
+                                let minor2 = (2.0 * PI * base * (2.0f32).powf(1.0 / 12.0) * time).sin()
+                                    * 0.10 * (-10.0 * time).exp();
+                                let drop = (2.0 * PI * base * (1.0 - progress * 0.3).max(0.5) * time).sin()
+                                    * 0.15 * (-6.0 * time).exp();
+                                tritone + minor2 + drop
+                            } else { 0.0 };
+
+                            let raw = (oneshot_out + error_layer) * vol * global_fade;
                             // Light reverb per slot
                             let wet = slot_reverbs[i].process(raw);
                             let with_reverb = raw * 0.88 + wet * 0.12;
@@ -3442,30 +3614,47 @@ fn parse_log_timestamp(ts: &str) -> Option<u64> {
     Some(days * 86400 + hour * 3600 + min * 60 + sec)
 }
 
-fn run_hook() -> Result<()> {
-    // Read stdin JSON from Claude Code hook, extract cwd, detect branch/repo, play tone.
-    // Never fails — every fallible op is silently absorbed so we never block Claude Code.
+/// Extract a string field from JSON, defaulting to "" if absent.
+fn json_str_field(json: &serde_json::Value, key: &str) -> String {
+    json.get(key).and_then(|v| v.as_str()).unwrap_or("").to_string()
+}
 
+fn run_hook() -> Result<()> {
     let mut input = String::new();
     std::io::stdin().read_to_string(&mut input).ok();
 
-    let mut hook_type = "unknown".to_string();
+    let mut ctx = HookContext::default();
+    ctx.event = "unknown".to_string();
 
     if let Ok(json) = serde_json::from_str::<serde_json::Value>(&input) {
         let cwd = json.get("cwd").and_then(|v| v.as_str()).unwrap_or(".");
         let _ = std::env::set_current_dir(cwd);
-        // Plugin system sends "hook_event_name"; legacy sends "hook_type"
         if let Some(ht) = json.get("hook_event_name").and_then(|v| v.as_str())
             .or_else(|| json.get("hook_type").and_then(|v| v.as_str()))
         {
-            hook_type = ht.to_string();
+            ctx.event = ht.to_string();
         }
+
+        ctx.session_id = json_str_field(&json, "session_id");
+        ctx.tool_name = json.get("tool_input")
+            .and_then(|t| t.get("tool_name").and_then(|v| v.as_str()))
+            .or_else(|| json.get("tool_name").and_then(|v| v.as_str()))
+            .unwrap_or("").to_string();
+        ctx.agent_type = json.get("subagent_type")
+            .and_then(|v| v.as_str())
+            .or_else(|| json.get("agent_type").and_then(|v| v.as_str()))
+            .unwrap_or("").to_string();
+        ctx.error_msg = json.get("error")
+            .and_then(|v| v.as_str())
+            .or_else(|| json.get("error_message").and_then(|v| v.as_str()))
+            .unwrap_or("").to_string();
     }
 
     let branch = get_current_branch().unwrap_or_else(|_| "claude".to_string());
     let repo = get_repo_name().unwrap_or_else(|_| "unknown".to_string());
+    ctx.repo = repo.clone();
+    ctx.branch = branch.clone();
 
-    // Append to event log (~/.branch-tone/events.log) — never fail
     if let Some(home) = dirs::home_dir() {
         let log_dir = home.join(".branch-tone");
         let _ = std::fs::create_dir_all(&log_dir);
@@ -3474,34 +3663,34 @@ fn run_hook() -> Result<()> {
             use std::time::SystemTime;
             let dur = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap_or_default();
             let secs = dur.as_secs();
-            // Format as ISO-ish timestamp (UTC)
             let s = secs % 60;
             let m = (secs / 60) % 60;
             let h = (secs / 3600) % 24;
             let days = secs / 86400;
-            // Simple date from days since epoch
             let (y, mo, d) = days_to_ymd(days);
             format!("{:04}-{:02}-{:02}T{:02}:{:02}:{:02}", y, mo, d, h, m, s)
         };
-        let line = format!("{} {} {} {}\n", now, hook_type, repo, branch);
+        let enrichment = if !ctx.tool_name.is_empty() || !ctx.agent_type.is_empty() {
+            format!("\t{}\t{}", ctx.tool_name, ctx.agent_type)
+        } else {
+            String::new()
+        };
+        let line = format!("{} {} {} {}{}\n", now, ctx.event, repo, branch, enrichment);
         use std::io::Write;
         if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open(&log_path) {
             let _ = f.write_all(line.as_bytes());
         }
     }
 
-    // Muted? Log was written above; skip all sound.
     if is_muted() {
         return Ok(());
     }
 
-    // Try daemon first: if running, send event via socket (zero-latency)
-    if send_to_daemon(&hook_type, &repo, &branch).is_ok() {
+    if send_to_daemon(&ctx).is_ok() {
         return Ok(());
     }
 
-    // Fallback: fire-and-forget (current behavior)
-    let mut args = hook_play_args(&hook_type, repo, branch, false);
+    let mut args = hook_play_args(&ctx.event, repo, branch, false);
 
     // Density-aware modulation: events in last 10s window
     // Busy bursts → richer echoes; quiet periods → sparser, more ambient
@@ -6736,75 +6925,117 @@ mod tui_app {
 
     // ── Event parsing & coloring ────────────────────────────────────────────
 
-    /// Parsed event log line
+    /// Parsed event log line with optional enrichment (tool_name, agent_type)
     struct ParsedEvent {
         timestamp: String,
         event_type: String,
         repo: String,
         branch: String,
+        tool_name: Option<String>,
+        agent_type: Option<String>,
     }
 
     impl ParsedEvent {
         fn parse(line: &str) -> Self {
+            // Log format: "timestamp event repo branch\ttool\tagent"
+            // Tab delimiter separates original 4 fields from enrichment
             let parts: Vec<&str> = line.splitn(4, ' ').collect();
+            let branch_and_enrichment = parts.get(3).unwrap_or(&"").to_string();
+
+            // Split field 4 on tab for enrichment
+            let mut tab_parts = branch_and_enrichment.splitn(3, '\t');
+            let branch = tab_parts.next().unwrap_or("").to_string();
+            let tool_name = tab_parts.next().map(|s| s.to_string()).filter(|s| !s.is_empty());
+            let agent_type = tab_parts.next().map(|s| s.to_string()).filter(|s| !s.is_empty());
+
             Self {
                 timestamp: parts.first().unwrap_or(&"").to_string(),
                 event_type: parts.get(1).unwrap_or(&"").to_string(),
                 repo: parts.get(2).unwrap_or(&"").to_string(),
-                branch: parts.get(3).unwrap_or(&"").to_string(),
+                branch,
+                tool_name,
+                agent_type,
             }
         }
 
         fn type_color(&self) -> Color {
             match self.event_type.as_str() {
-                "SessionStart" => Color::Cyan,
+                "SessionStart" | "Setup" => Color::Cyan,
                 "SessionEnd" => Color::Blue,
-                "PreToolUse" => Color::Green,
-                "PostToolUse" => Color::Green,
-                "PostToolUseFailure" => Color::Red,
+                "PreToolUse" | "PostToolUse" | "FileChanged" => Color::Green,
+                "PostToolUseFailure" | "StopFailure" | "PermissionDenied" => Color::Red,
                 "UserPromptSubmit" => Color::Yellow,
-                "Notification" => Color::Yellow,
+                "Notification" | "Elicitation" | "ElicitationResult" => Color::Yellow,
                 "Stop" => Color::Magenta,
                 "SubagentStart" | "SubagentStop" => Color::Blue,
-                "TaskCompleted" => Color::Cyan,
-                "PreCompact" => Color::DarkGray,
-                "ConfigChange" | "InstructionsLoaded" => Color::DarkGray,
+                "TaskCompleted" | "TaskCreated" => Color::Cyan,
+                "PreCompact" | "PostCompact" => Color::DarkGray,
+                "ConfigChange" | "InstructionsLoaded" | "CwdChanged" => Color::DarkGray,
                 "PermissionRequest" => Color::Yellow,
                 "TeammateIdle" => Color::DarkGray,
                 _ => Color::White,
             }
         }
 
-        /// Short label for compact display
+        /// Short label for compact display — tool-aware for ToolPulse events
         fn type_label(&self) -> &str {
             match self.event_type.as_str() {
                 "SessionStart" => "START",
                 "SessionEnd" => "END",
-                "PreToolUse" => "TOOL",
-                "PostToolUse" => "TOOL",
+                "PreToolUse" | "PostToolUse" => {
+                    match self.tool_name.as_deref() {
+                        Some("Read" | "Glob" | "Grep") => "READ",
+                        Some("Write" | "Edit") => "WRITE",
+                        Some("Bash") => "BASH",
+                        Some("Agent") => "AGENT",
+                        Some("WebSearch" | "WebFetch") => "WEB",
+                        Some(_) => "TOOL",
+                        None => "TOOL",
+                    }
+                }
                 "PostToolUseFailure" => "FAIL",
                 "UserPromptSubmit" => "PROMPT",
                 "Notification" => "NOTIF",
                 "Stop" => "STOP",
+                "StopFailure" => "STOP!",
                 "SubagentStart" => "AGENT+",
                 "SubagentStop" => "AGENT-",
-                "TaskCompleted" => "TASK",
-                "PreCompact" => "COMPACT",
+                "TaskCompleted" => "TASK\u{2713}",
+                "TaskCreated" => "TASK+",
+                "PreCompact" | "PostCompact" => "COMPACT",
                 "ConfigChange" => "CONFIG",
                 "InstructionsLoaded" => "INIT",
+                "Setup" => "SETUP",
                 "PermissionRequest" => "PERM",
+                "PermissionDenied" => "DENY",
                 "TeammateIdle" => "IDLE",
+                "CwdChanged" => "CWD",
+                "FileChanged" => "FILE",
+                "Elicitation" => "ASK",
+                "ElicitationResult" => "ANSWER",
                 _ => &self.event_type,
+            }
+        }
+
+        /// Color for tool badge based on tool family
+        fn tool_badge_color(&self) -> Option<Color> {
+            match self.tool_name.as_deref()? {
+                "Read" | "Glob" | "Grep" => Some(Color::Cyan),
+                "Write" | "Edit" => Some(Color::Yellow),
+                "Bash" => Some(Color::Red),
+                "Agent" => Some(Color::Blue),
+                "WebSearch" | "WebFetch" => Some(Color::Magenta),
+                _ => Some(Color::DarkGray),
             }
         }
 
         /// Event type category for activity bucketing
         fn type_category(&self) -> EventTypeCategory {
             match self.event_type.as_str() {
-                "PreToolUse" | "PostToolUse" | "PostToolUseFailure" => EventTypeCategory::Tool,
-                "UserPromptSubmit" => EventTypeCategory::Prompt,
-                "SessionStart" | "SessionEnd" => EventTypeCategory::Session,
-                "SubagentStart" | "SubagentStop" | "TaskCompleted" | "TeammateIdle" => EventTypeCategory::Agent,
+                "PreToolUse" | "PostToolUse" | "PostToolUseFailure" | "FileChanged" => EventTypeCategory::Tool,
+                "UserPromptSubmit" | "Elicitation" | "ElicitationResult" => EventTypeCategory::Prompt,
+                "SessionStart" | "SessionEnd" | "Setup" => EventTypeCategory::Session,
+                "SubagentStart" | "SubagentStop" | "TaskCompleted" | "TaskCreated" | "TeammateIdle" => EventTypeCategory::Agent,
                 _ => EventTypeCategory::Other,
             }
         }
@@ -7601,16 +7832,28 @@ mod tui_app {
         }
 
         let max_val = state.activity.total.iter().copied().max().unwrap_or(1).max(1);
-        let col_height = inner.height as u64;
+        // Reserve bottom row for timestamp labels
+        let bar_height = inner.height.saturating_sub(1) as u64;
+        if bar_height == 0 { return; }
 
+        // ── Y-axis scale: max count at top-left ──
+        let scale_str = format!("{}", max_val);
+        for (ci, ch) in scale_str.chars().enumerate() {
+            let x = inner.x + ci as u16;
+            if x < inner.x + inner.width {
+                frame.buffer_mut()[(x, inner.y)].set_char(ch).set_fg(Color::DarkGray);
+            }
+        }
+
+        // ── Bars ──
         for col in 0..inner.width as usize {
             if col >= state.activity.total.len() { break; }
-            let mut y_cursor = inner.y + inner.height;
+            let mut y_cursor = inner.y + inner.height - 1; // leave bottom row for timestamps
             for (cat, buckets) in &state.activity.per_category {
                 if col >= buckets.len() { continue; }
                 let val = buckets[col];
                 if val == 0 { continue; }
-                let bar_h = ((val * col_height) / max_val).max(if val > 0 { 1 } else { 0 }) as u16;
+                let bar_h = ((val * bar_height) / max_val).max(if val > 0 { 1 } else { 0 }) as u16;
                 for _dy in 0..bar_h {
                     if y_cursor == inner.y { break; }
                     y_cursor -= 1;
@@ -7618,6 +7861,38 @@ mod tui_app {
                     if x < inner.x + inner.width && y_cursor >= inner.y {
                         frame.buffer_mut()[(x, y_cursor)].set_char('█').set_fg(cat.color());
                     }
+                }
+            }
+        }
+
+        // ── X-axis timestamps ──
+        let num_cols = inner.width as usize;
+        let bucket_secs = state.timescale.bucket_secs(num_cols as u64);
+        let offset_secs = state.time_offset as u64 * bucket_secs;
+        let y_label = inner.y + inner.height - 1;
+
+        // Place ~4-5 evenly spaced time labels
+        let label_count = (num_cols / 12).max(2).min(6);
+        for li in 0..label_count {
+            let col = if label_count <= 1 { num_cols - 1 }
+                else { li * (num_cols - 1) / (label_count - 1) };
+            // Time for this column: rightmost col = now - offset, leftmost = now - offset - window
+            let cols_from_right = (num_cols - 1).saturating_sub(col) as u64;
+            let secs_ago = offset_secs + cols_from_right * bucket_secs;
+            let label = if secs_ago == 0 {
+                "now".to_string()
+            } else if secs_ago < 60 {
+                format!("-{}s", secs_ago)
+            } else if secs_ago < 3600 {
+                format!("-{}m", secs_ago / 60)
+            } else {
+                format!("-{}h", secs_ago / 3600)
+            };
+            let start_x = inner.x + col as u16;
+            for (ci, ch) in label.chars().enumerate() {
+                let x = start_x + ci as u16;
+                if x < inner.x + inner.width {
+                    frame.buffer_mut()[(x, y_label)].set_char(ch).set_fg(Color::DarkGray);
                 }
             }
         }
@@ -7664,13 +7939,29 @@ mod tui_app {
             let time_color = if is_newest { Color::White } else { Color::DarkGray };
             let branch_color = if is_newest { Color::White } else { Color::DarkGray };
 
-            Line::from(vec![
+            let mut spans = vec![
                 Span::styled(lane_char, Style::default().fg(lane_color)),
                 Span::styled(format!(" {} ", time_str), Style::default().fg(time_color)),
                 Span::styled(format!("{:<7}", evt.type_label()), Style::default().fg(type_color).add_modifier(if is_newest { Modifier::BOLD } else { Modifier::empty() })),
                 Span::styled(format!(" {}", evt.repo), Style::default().fg(repo_color)),
                 Span::styled(format!("/{}", evt.branch), Style::default().fg(branch_color)),
-            ])
+            ];
+            // Tool badge: [Read], [Bash], etc.
+            if let Some(tool) = &evt.tool_name {
+                let badge_color = evt.tool_badge_color().unwrap_or(Color::DarkGray);
+                spans.push(Span::styled(
+                    format!(" [{}]", tool),
+                    Style::default().fg(if is_newest { Color::White } else { badge_color }),
+                ));
+            }
+            // Agent badge: <worker>, <researcher>, etc.
+            if let Some(agent) = &evt.agent_type {
+                spans.push(Span::styled(
+                    format!(" <{}>", agent),
+                    Style::default().fg(if is_newest { Color::White } else { Color::Blue }),
+                ));
+            }
+            Line::from(spans)
         }).collect();
 
         let scroll_hint = if state.stream_scroll > 0 {
@@ -7880,6 +8171,71 @@ mod tui_app {
             assert_eq!(voice_color_for_repo("repo-a", &voices), VOICE_COLORS[0]);
             assert_eq!(voice_color_for_repo("repo-b", &voices), VOICE_COLORS[1]);
             assert_eq!(voice_color_for_repo("unknown", &voices), Color::DarkGray);
+        }
+
+        #[test]
+        fn parsed_event_enrichment() {
+            // Old format: no tab enrichment
+            let old = ParsedEvent::parse("2026-04-02T12:00:00 PreToolUse my-repo main");
+            assert_eq!(old.branch, "main");
+            assert!(old.tool_name.is_none());
+            assert!(old.agent_type.is_none());
+
+            // New format: tab-delimited enrichment
+            let new = ParsedEvent::parse("2026-04-02T12:00:00 PreToolUse my-repo main\tRead\t");
+            assert_eq!(new.branch, "main");
+            assert_eq!(new.tool_name.as_deref(), Some("Read"));
+            assert!(new.agent_type.is_none()); // empty string filtered
+
+            // Full enrichment
+            let full = ParsedEvent::parse("2026-04-02T12:00:00 SubagentStart my-repo feat\t\tworker");
+            assert_eq!(full.branch, "feat");
+            assert!(full.tool_name.is_none()); // empty tool
+            assert_eq!(full.agent_type.as_deref(), Some("worker"));
+        }
+
+        #[test]
+        fn tool_aware_type_labels() {
+            let read_evt = ParsedEvent {
+                timestamp: String::new(), event_type: "PreToolUse".into(),
+                repo: "r".into(), branch: "b".into(),
+                tool_name: Some("Read".into()), agent_type: None,
+            };
+            assert_eq!(read_evt.type_label(), "READ");
+
+            let bash_evt = ParsedEvent {
+                timestamp: String::new(), event_type: "PostToolUse".into(),
+                repo: "r".into(), branch: "b".into(),
+                tool_name: Some("Bash".into()), agent_type: None,
+            };
+            assert_eq!(bash_evt.type_label(), "BASH");
+
+            let no_tool = ParsedEvent {
+                timestamp: String::new(), event_type: "PreToolUse".into(),
+                repo: "r".into(), branch: "b".into(),
+                tool_name: None, agent_type: None,
+            };
+            assert_eq!(no_tool.type_label(), "TOOL");
+        }
+
+        #[test]
+        fn new_event_type_colors() {
+            let setup = ParsedEvent::parse("2026-04-02T12:00:00 Setup r b");
+            assert_eq!(setup.type_color(), Color::Cyan);
+            let stop_fail = ParsedEvent::parse("2026-04-02T12:00:00 StopFailure r b");
+            assert_eq!(stop_fail.type_color(), Color::Red);
+            let elicit = ParsedEvent::parse("2026-04-02T12:00:00 Elicitation r b");
+            assert_eq!(elicit.type_color(), Color::Yellow);
+        }
+
+        #[test]
+        fn new_event_categories() {
+            let file = ParsedEvent::parse("2026-04-02T12:00:00 FileChanged r b");
+            assert_eq!(file.type_category(), EventTypeCategory::Tool);
+            let task = ParsedEvent::parse("2026-04-02T12:00:00 TaskCreated r b");
+            assert_eq!(task.type_category(), EventTypeCategory::Agent);
+            let setup = ParsedEvent::parse("2026-04-02T12:00:00 Setup r b");
+            assert_eq!(setup.type_category(), EventTypeCategory::Session);
         }
 
         #[test]
@@ -8961,6 +9317,98 @@ mod tests {
         }
     }
 
+    // -- Tool timbral mapping tests --
+
+    #[test]
+    fn tool_timbral_params_differentiated() {
+        let read = tool_timbral_params("Read");
+        let bash = tool_timbral_params("Bash");
+        let write = tool_timbral_params("Write");
+        let agent = tool_timbral_params("Agent");
+        let unknown = tool_timbral_params("UnknownTool");
+
+        // Read: bright (high filter), 2nd harmonic
+        assert!(read.0 > 1.0, "Read should have high filter");
+        assert_eq!(read.2 & 0b001, 0b001, "Read should have 2nd harmonic");
+
+        // Bash: saw boost
+        assert_eq!(bash.2 & 0b100, 0b100, "Bash should have saw boost");
+        assert!(bash.1 > write.1, "Bash should have more detune than Write");
+
+        // Write: warm (low filter)
+        assert!(write.0 < 1.0, "Write should have low filter");
+
+        // Agent: 2nd+3rd harmonics
+        assert_eq!(agent.2 & 0b011, 0b011, "Agent should have 2nd+3rd harmonics");
+
+        // Unknown: neutral
+        assert_eq!(unknown.0, 1.0);
+        assert_eq!(unknown.1, 0.0);
+        assert_eq!(unknown.2, 0);
+    }
+
+    #[test]
+    fn agent_octave_shift_covers_register_range() {
+        let researcher = agent_octave_shift("researcher");
+        let worker = agent_octave_shift("worker");
+        let validator = agent_octave_shift("validator");
+        let scout = agent_octave_shift("scout");
+        let unknown = agent_octave_shift("whatever");
+
+        // Researcher lowest, scout highest
+        assert!(researcher < worker, "researcher should be below worker");
+        assert!(worker < validator, "worker should be below validator");
+        assert!(validator < scout, "validator should be below scout");
+        assert_eq!(unknown, 1.0, "unknown agent should be center");
+    }
+
+    #[test]
+    fn hook_context_default_all_empty() {
+        let ctx = HookContext::default();
+        assert!(ctx.event.is_empty());
+        assert!(ctx.tool_name.is_empty());
+        assert!(ctx.agent_type.is_empty());
+        assert!(ctx.error_msg.is_empty());
+        assert!(ctx.session_id.is_empty());
+    }
+
+    #[test]
+    fn all_27_events_have_play_args() {
+        assert_eq!(HOOK_EVENTS.len(), 27, "should have 27 hook events");
+        for event in HOOK_EVENTS {
+            let args = hook_play_args(event, "r".into(), "b".into(), false);
+            assert!(args.volume > 0.0, "{} should have positive volume", event);
+            assert!(args.duration > 0, "{} should have positive duration", event);
+        }
+    }
+
+    #[test]
+    fn error_events_get_attention_category() {
+        let stop_fail = hook_play_args("StopFailure", "r".into(), "b".into(), false);
+        let perm_denied = hook_play_args("PermissionDenied", "r".into(), "b".into(), false);
+        assert_eq!(stop_fail.event_category, EventCategory::Attention);
+        assert_eq!(perm_denied.event_category, EventCategory::Attention);
+    }
+
+    #[test]
+    fn queued_note_carries_tool_params() {
+        let note = QueuedNote {
+            category: category_to_u8(EventCategory::ToolPulse),
+            volume: 0.1, duration_ms: 100, note_freq: 440.0,
+            tool_filter: 1.4, tool_detune: 2.0, tool_harmonics: 0b001, is_error: false,
+        };
+        assert_eq!(note.tool_filter, 1.4);
+        assert_eq!(note.tool_harmonics & 0b001, 0b001);
+        assert!(!note.is_error);
+
+        let err_note = QueuedNote {
+            category: category_to_u8(EventCategory::ToolPulse),
+            volume: 0.1, duration_ms: 100, note_freq: 440.0,
+            tool_filter: 1.0, tool_detune: 0.0, tool_harmonics: 0, is_error: true,
+        };
+        assert!(err_note.is_error);
+    }
+
     // -- Init CLI arg tests --
 
     #[test]
@@ -9684,6 +10132,7 @@ mod tests {
                         volume: args.volume,
                         duration_ms: per_note_ms.max(150),
                         note_freq: freq,
+                        tool_filter: 1.0, tool_detune: 0.0, tool_harmonics: 0, is_error: false,
                     });
                 }
             }
@@ -9720,6 +10169,7 @@ mod tests {
                 volume: args.volume,
                 duration_ms: args.duration as u32,
                 note_freq,
+                tool_filter: 1.0, tool_detune: 0.0, tool_harmonics: 0, is_error: false,
             });
         }
 
@@ -9752,6 +10202,7 @@ mod tests {
                 volume: args.volume,
                 duration_ms: args.duration as u32,
                 note_freq,
+                tool_filter: 1.0, tool_detune: 0.0, tool_harmonics: 0, is_error: false,
             });
         }
 
@@ -9816,6 +10267,7 @@ mod tests {
                         volume: args.volume,
                         duration_ms: per_note_ms.max(150),
                         note_freq: freq,
+                        tool_filter: 1.0, tool_detune: 0.0, tool_harmonics: 0, is_error: false,
                     });
                 }
             }
@@ -9999,6 +10451,7 @@ mod tests {
                         volume: 0.1,
                         duration_ms: 100,
                         note_freq: 440.0 + i as f32,
+                        tool_filter: 1.0, tool_detune: 0.0, tool_harmonics: 0, is_error: false,
                     });
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7365,6 +7365,7 @@ mod tui_app {
         rect_stream: Rect,
         rect_status: Rect,
         activity_cols: usize,  // last-known inner width for activity panel
+        activity_height: u16,  // user-adjustable height for activity panel (default 7)
         last_poll: Instant,
     }
 
@@ -7393,6 +7394,7 @@ mod tui_app {
                 rect_stream: Rect::default(),
                 rect_status: Rect::default(),
                 activity_cols: 80, // reasonable default until first render
+                activity_height: 7, // default activity panel height
                 last_poll: Instant::now() - Duration::from_secs(10),
             }
         }
@@ -7575,6 +7577,16 @@ mod tui_app {
                 Action::Continue
             }
 
+            // Panel resize: [ shrinks activity, ] grows it
+            KeyCode::Char('[') => {
+                state.activity_height = state.activity_height.saturating_sub(1).max(5);
+                Action::Continue
+            }
+            KeyCode::Char(']') => {
+                state.activity_height = (state.activity_height + 1).min(10);
+                Action::Continue
+            }
+
             // Stream scrolling
             KeyCode::Char('j') | KeyCode::Down => {
                 state.stream_scroll = state.stream_scroll.saturating_sub(1);
@@ -7739,10 +7751,10 @@ mod tui_app {
         let chunks = Layout::default()
             .direction(Direction::Vertical)
             .constraints([
-                Constraint::Length(3),   // status bar
-                Constraint::Length(5),   // activity bars (per-category)
-                Constraint::Min(8),     // merged voice+events stream
-                Constraint::Length(1),   // keybind footer
+                Constraint::Length(3),                       // status bar
+                Constraint::Length(state.activity_height),   // activity (resizable)
+                Constraint::Min(8),                         // stream (fills remaining)
+                Constraint::Length(1),                       // keybind footer
             ])
             .split(area);
 
@@ -7871,23 +7883,22 @@ mod tui_app {
         let offset_secs = state.time_offset as u64 * bucket_secs;
         let y_label = inner.y + inner.height - 1;
 
-        // Place ~4-5 evenly spaced time labels
+        // Place evenly spaced absolute time labels (HH:MM format)
+        let now_epoch = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
         let label_count = (num_cols / 12).max(2).min(6);
         for li in 0..label_count {
             let col = if label_count <= 1 { num_cols - 1 }
                 else { li * (num_cols - 1) / (label_count - 1) };
-            // Time for this column: rightmost col = now - offset, leftmost = now - offset - window
             let cols_from_right = (num_cols - 1).saturating_sub(col) as u64;
             let secs_ago = offset_secs + cols_from_right * bucket_secs;
-            let label = if secs_ago == 0 {
-                "now".to_string()
-            } else if secs_ago < 60 {
-                format!("-{}s", secs_ago)
-            } else if secs_ago < 3600 {
-                format!("-{}m", secs_ago / 60)
-            } else {
-                format!("-{}h", secs_ago / 3600)
-            };
+            let epoch_at_col = now_epoch.saturating_sub(secs_ago);
+            // Convert epoch to HH:MM (local-ish: UTC for simplicity, matches log timestamps)
+            let h = (epoch_at_col / 3600) % 24;
+            let m = (epoch_at_col / 60) % 60;
+            let label = format!("{:02}:{:02}", h, m);
             let start_x = inner.x + col as u16;
             for (ci, ch) in label.chars().enumerate() {
                 let x = start_x + ci as u16;
@@ -8023,6 +8034,8 @@ mod tui_app {
             Span::styled(" [p]alette ", Style::default().fg(Color::Yellow)),
             Span::styled("│", Style::default().fg(Color::DarkGray)),
             Span::styled(" [+/-]zoom ", Style::default().fg(Color::White)),
+            Span::styled("│", Style::default().fg(Color::DarkGray)),
+            Span::styled(" [/]resize ", Style::default().fg(Color::White)),
             Span::styled("│", Style::default().fg(Color::DarkGray)),
             Span::styled(" [q]uit ", Style::default().fg(Color::White)),
         ]);

--- a/src/main.rs
+++ b/src/main.rs
@@ -214,6 +214,10 @@ enum Command {
         uninstall: bool,
     },
 
+    /// Terminal dashboard for monitoring and controlling the daemon
+    #[cfg(feature = "tui")]
+    Tui,
+
     /// Interactive step sequencer — toggle drum hits in real-time
     Player {
         /// Starting break pattern (0=Amen, 1=Think, 2=Funky Drummer, 3=Apache,
@@ -1507,6 +1511,7 @@ impl BranchMelody {
 
 /// Map quantize subdivision multiplier to a musical label.
 fn subdiv_label(subdiv: f32) -> &'static str {
+    if subdiv < 0.1 { return "off"; } // free timing
     match subdiv as u8 {
         0 => "1/32",  // 0.5 truncates to 0
         1 => "1/16",
@@ -1677,6 +1682,8 @@ fn main() -> Result<()> {
             }
             run_tray(foreground)
         }
+        #[cfg(feature = "tui")]
+        Some(Command::Tui) => tui_app::run(),
         Some(Command::Player { pattern, bpm }) => run_player(pattern, bpm),
         None => run_play(cli.play_args),
     }
@@ -2368,15 +2375,18 @@ fn quantize_file_path() -> std::path::PathBuf {
 }
 
 /// Read persisted quantize override. Returns None for "auto" (hash-derived).
+/// 0 = off (free timing), 4/8/16/32 = grid denominators.
 fn get_quantize() -> Option<u32> {
     std::fs::read_to_string(quantize_file_path()).ok()
         .and_then(|s| s.trim().parse::<u32>().ok())
-        .filter(|&d| matches!(d, 4 | 8 | 16 | 32))
+        .filter(|&d| matches!(d, 0 | 4 | 8 | 16 | 32))
 }
 
-/// Map quantize denominator (4/8/16/32) to subdivision multiplier.
+/// Map quantize denominator (0/4/8/16/32) to subdivision multiplier.
+/// 0 = off: uses a tiny subdivision so events play immediately without grid snap.
 fn quantize_denom_to_subdiv(denom: u32) -> f32 {
     match denom {
+        0 => 0.01, // effectively no grid — events play instantly
         4 => 4.0,
         8 => 2.0,
         16 => 1.0,
@@ -6700,6 +6710,1208 @@ fn run_player(initial_pattern: usize, initial_bpm: Option<u16>) -> Result<()> {
     }
 
     Ok(())
+}
+
+// =============================================================================
+// TUI: Terminal dashboard for daemon monitoring and control
+// =============================================================================
+
+#[cfg(feature = "tui")]
+mod tui_app {
+    use std::time::{Duration, Instant};
+
+    use anyhow::{Context, Result};
+    use ratatui::backend::CrosstermBackend;
+    use ratatui::layout::{Constraint, Direction, Layout, Rect};
+    use ratatui::style::{Color, Modifier, Style};
+    use ratatui::text::{Line, Span};
+    use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph};
+    use ratatui::Terminal;
+
+    use super::{
+        daemon_dir, daemon_pid_path, daemon_socket_path, drone_mute_path,
+        get_quantize, get_seed, is_drone_muted, is_muted, mute_file_path,
+        quantize_file_path, seed_file_path, subdiv_label, SEED_PRESETS,
+    };
+
+    // ── Event parsing & coloring ────────────────────────────────────────────
+
+    /// Parsed event log line
+    struct ParsedEvent {
+        timestamp: String,
+        event_type: String,
+        repo: String,
+        branch: String,
+    }
+
+    impl ParsedEvent {
+        fn parse(line: &str) -> Self {
+            let parts: Vec<&str> = line.splitn(4, ' ').collect();
+            Self {
+                timestamp: parts.first().unwrap_or(&"").to_string(),
+                event_type: parts.get(1).unwrap_or(&"").to_string(),
+                repo: parts.get(2).unwrap_or(&"").to_string(),
+                branch: parts.get(3).unwrap_or(&"").to_string(),
+            }
+        }
+
+        fn type_color(&self) -> Color {
+            match self.event_type.as_str() {
+                "SessionStart" => Color::Cyan,
+                "SessionEnd" => Color::Blue,
+                "PreToolUse" => Color::Green,
+                "PostToolUse" => Color::Green,
+                "PostToolUseFailure" => Color::Red,
+                "UserPromptSubmit" => Color::Yellow,
+                "Notification" => Color::Yellow,
+                "Stop" => Color::Magenta,
+                "SubagentStart" | "SubagentStop" => Color::Blue,
+                "TaskCompleted" => Color::Cyan,
+                "PreCompact" => Color::DarkGray,
+                "ConfigChange" | "InstructionsLoaded" => Color::DarkGray,
+                "PermissionRequest" => Color::Yellow,
+                "TeammateIdle" => Color::DarkGray,
+                _ => Color::White,
+            }
+        }
+
+        /// Short label for compact display
+        fn type_label(&self) -> &str {
+            match self.event_type.as_str() {
+                "SessionStart" => "START",
+                "SessionEnd" => "END",
+                "PreToolUse" => "TOOL",
+                "PostToolUse" => "TOOL",
+                "PostToolUseFailure" => "FAIL",
+                "UserPromptSubmit" => "PROMPT",
+                "Notification" => "NOTIF",
+                "Stop" => "STOP",
+                "SubagentStart" => "AGENT+",
+                "SubagentStop" => "AGENT-",
+                "TaskCompleted" => "TASK",
+                "PreCompact" => "COMPACT",
+                "ConfigChange" => "CONFIG",
+                "InstructionsLoaded" => "INIT",
+                "PermissionRequest" => "PERM",
+                "TeammateIdle" => "IDLE",
+                _ => &self.event_type,
+            }
+        }
+
+        /// Event type category for activity bucketing
+        fn type_category(&self) -> EventTypeCategory {
+            match self.event_type.as_str() {
+                "PreToolUse" | "PostToolUse" | "PostToolUseFailure" => EventTypeCategory::Tool,
+                "UserPromptSubmit" => EventTypeCategory::Prompt,
+                "SessionStart" | "SessionEnd" => EventTypeCategory::Session,
+                "SubagentStart" | "SubagentStop" | "TaskCompleted" | "TeammateIdle" => EventTypeCategory::Agent,
+                _ => EventTypeCategory::Other,
+            }
+        }
+    }
+
+    #[derive(Clone, Copy, Debug, PartialEq)]
+    enum EventTypeCategory {
+        Tool,
+        Prompt,
+        Session,
+        Agent,
+        Other,
+    }
+
+    impl EventTypeCategory {
+        fn color(self) -> Color {
+            match self {
+                Self::Tool => Color::Green,
+                Self::Prompt => Color::Yellow,
+                Self::Session => Color::Cyan,
+                Self::Agent => Color::Blue,
+                Self::Other => Color::DarkGray,
+            }
+        }
+
+        #[cfg(test)]
+        fn label(self) -> &'static str {
+            match self {
+                Self::Tool => "tool",
+                Self::Prompt => "prompt",
+                Self::Session => "session",
+                Self::Agent => "agent",
+                Self::Other => "other",
+            }
+        }
+    }
+
+    const ALL_CATEGORIES: [EventTypeCategory; 5] = [
+        EventTypeCategory::Tool,
+        EventTypeCategory::Prompt,
+        EventTypeCategory::Session,
+        EventTypeCategory::Agent,
+        EventTypeCategory::Other,
+    ];
+
+    /// Stable color palette for voice slots (up to 8)
+    const VOICE_COLORS: [Color; 8] = [
+        Color::Cyan, Color::Green, Color::Yellow, Color::Magenta,
+        Color::Blue, Color::Red, Color::LightCyan, Color::LightGreen,
+    ];
+
+    fn voice_color_for_repo(repo: &str, voices: &[(usize, String, String)]) -> Color {
+        voices.iter()
+            .position(|(_, r, _)| r == repo)
+            .map(|i| VOICE_COLORS[i % VOICE_COLORS.len()])
+            .unwrap_or(Color::DarkGray)
+    }
+
+    /// Zoom levels for the activity histogram
+    #[derive(Clone, Copy, Debug, PartialEq)]
+    enum TimeScale {
+        Min5,    // 5 min, 5s buckets
+        Min15,   // 15 min, 15s buckets
+        Hour1,   // 1 hour, 1 min buckets
+        Hour4,   // 4 hours, 4 min buckets
+        Hour24,  // 24 hours, 24 min buckets
+    }
+
+    impl TimeScale {
+        fn label(self) -> &'static str {
+            match self {
+                Self::Min5 => "5 min",
+                Self::Min15 => "15 min",
+                Self::Hour1 => "1 hour",
+                Self::Hour4 => "4 hours",
+                Self::Hour24 => "24 hours",
+            }
+        }
+
+        /// Total window in seconds
+        fn window_secs(self) -> u64 {
+            match self {
+                Self::Min5 => 5 * 60,
+                Self::Min15 => 15 * 60,
+                Self::Hour1 => 60 * 60,
+                Self::Hour4 => 4 * 60 * 60,
+                Self::Hour24 => 24 * 60 * 60,
+            }
+        }
+
+        /// Seconds per bucket for a given number of columns
+        fn bucket_secs(self, num_cols: u64) -> u64 {
+            (self.window_secs() / num_cols).max(1)
+        }
+
+        /// How many log lines to read (wider windows need more history)
+        fn log_lines(self) -> usize {
+            match self {
+                Self::Min5 | Self::Min15 => 500,
+                Self::Hour1 => 2000,
+                Self::Hour4 => 5000,
+                Self::Hour24 => 10000,
+            }
+        }
+
+        fn zoom_in(self) -> Self {
+            match self {
+                Self::Min5 => Self::Min5,
+                Self::Min15 => Self::Min5,
+                Self::Hour1 => Self::Min15,
+                Self::Hour4 => Self::Hour1,
+                Self::Hour24 => Self::Hour4,
+            }
+        }
+
+        fn zoom_out(self) -> Self {
+            match self {
+                Self::Min5 => Self::Min15,
+                Self::Min15 => Self::Hour1,
+                Self::Hour1 => Self::Hour4,
+                Self::Hour4 => Self::Hour24,
+                Self::Hour24 => Self::Hour24,
+            }
+        }
+    }
+
+    /// Per-category activity data: 60 buckets at current timescale
+    struct ActivityData {
+        per_category: Vec<(EventTypeCategory, Vec<u64>)>,
+        total: Vec<u64>,
+        total_events: u64,
+    }
+
+    fn build_activity_data(events: &[ParsedEvent], scale: TimeScale, time_offset: i64, num_cols: usize) -> ActivityData {
+        let now = {
+            use std::time::SystemTime;
+            SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap_or_default().as_secs()
+        };
+
+        let num_cols = num_cols.max(1);
+        let bucket_secs = scale.bucket_secs(num_cols as u64);
+        let offset_secs = time_offset as u64 * bucket_secs;
+        let mut total = vec![0u64; num_cols];
+        let mut cat_buckets: Vec<Vec<u64>> = ALL_CATEGORIES.iter().map(|_| vec![0u64; num_cols]).collect();
+
+        for evt in events {
+            if let Some(epoch) = parse_timestamp_epoch(&evt.timestamp) {
+                let age_secs = now.saturating_sub(epoch);
+                if age_secs < offset_secs { continue; }
+                let shifted_age = age_secs - offset_secs;
+                let bucket_idx = shifted_age / bucket_secs;
+                if (bucket_idx as usize) < num_cols {
+                    let idx = num_cols - 1 - bucket_idx as usize;
+                    total[idx] += 1;
+                    let cat_idx = ALL_CATEGORIES.iter().position(|&c| c == evt.type_category()).unwrap_or(4);
+                    cat_buckets[cat_idx][idx] += 1;
+                }
+            }
+        }
+
+        let total_events = total.iter().sum();
+        ActivityData {
+            per_category: ALL_CATEGORIES.iter().copied().zip(cat_buckets.into_iter()).collect(),
+            total,
+            total_events,
+        }
+    }
+
+    /// Parse ISO timestamp to epoch seconds
+    fn parse_timestamp_epoch(ts: &str) -> Option<u64> {
+        let parts: Vec<&str> = ts.split('T').collect();
+        if parts.len() != 2 { return None; }
+        let date_parts: Vec<u64> = parts[0].split('-').filter_map(|s| s.parse().ok()).collect();
+        let time_parts: Vec<u64> = parts[1].split(':').filter_map(|s| s.parse().ok()).collect();
+        if date_parts.len() != 3 || time_parts.len() != 3 { return None; }
+        let (y, m, d) = (date_parts[0], date_parts[1], date_parts[2]);
+        let days = ymd_to_days(y, m, d);
+        Some(days * 86400 + time_parts[0] * 3600 + time_parts[1] * 60 + time_parts[2])
+    }
+
+    fn ymd_to_days(y: u64, m: u64, d: u64) -> u64 {
+        let y = if m <= 2 { y - 1 } else { y };
+        let m = if m <= 2 { m + 9 } else { m - 3 };
+        let era = y / 400;
+        let yoe = y - era * 400;
+        let doy = (153 * m + 2) / 5 + d - 1;
+        let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+        era * 146097 + doe - 719468
+    }
+
+    // ── Daemon socket client (ported from tray module) ──────────────────────
+
+    #[derive(Default)]
+    struct DaemonStatus {
+        pid: u32,
+        uptime_secs: u64,
+        active_voices: Vec<(usize, String, String)>, // (slot, repo, branch)
+        idle_secs: u64,
+        idle_timeout: u64,
+        running: bool,
+    }
+
+    fn query_daemon_status() -> DaemonStatus {
+        use std::io::{Read, Write};
+
+        let sock = daemon_socket_path();
+        let mut status = DaemonStatus::default();
+
+        let Ok(mut stream) = std::os::unix::net::UnixStream::connect(&sock) else {
+            return status;
+        };
+        stream.set_read_timeout(Some(Duration::from_millis(500))).ok();
+        stream.set_write_timeout(Some(Duration::from_millis(500))).ok();
+        let _ = stream.write_all(b"{\"event\":\"__status_json\"}\n");
+
+        let mut buf = vec![0u8; 4096];
+        let Ok(n) = stream.read(&mut buf) else {
+            return status;
+        };
+
+        let json_str = String::from_utf8_lossy(&buf[..n]);
+        let Ok(json) = serde_json::from_str::<serde_json::Value>(json_str.trim()) else {
+            return status;
+        };
+
+        status.running = true;
+        status.pid = json.get("pid").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
+        status.uptime_secs = json.get("uptime_secs").and_then(|v| v.as_u64()).unwrap_or(0);
+        status.idle_secs = json.get("idle_secs").and_then(|v| v.as_u64()).unwrap_or(0);
+        status.idle_timeout = json.get("idle_timeout").and_then(|v| v.as_u64()).unwrap_or(300);
+
+        if let Some(voices) = json.get("active_voices").and_then(|v| v.as_array()) {
+            for v in voices {
+                let slot = v.get("slot").and_then(|s| s.as_u64()).unwrap_or(0) as usize;
+                let repo = v.get("repo").and_then(|s| s.as_str()).unwrap_or("").to_string();
+                let branch = v.get("branch").and_then(|s| s.as_str()).unwrap_or("").to_string();
+                status.active_voices.push((slot, repo, branch));
+            }
+        }
+
+        status
+    }
+
+    fn is_daemon_running() -> bool {
+        let pid_path = daemon_pid_path();
+        if !pid_path.exists() {
+            return false;
+        }
+        let Ok(pid_str) = std::fs::read_to_string(&pid_path) else {
+            return false;
+        };
+        let Ok(pid) = pid_str.trim().parse::<u32>() else {
+            return false;
+        };
+        std::process::Command::new("kill")
+            .args(["-0", &pid.to_string()])
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+
+    fn start_daemon() {
+        if is_daemon_running() {
+            return;
+        }
+        let Ok(exe) = std::env::current_exe() else { return };
+        let _ = std::process::Command::new(exe)
+            .args(["daemon", "--detach"])
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn();
+    }
+
+    fn stop_daemon() {
+        use std::io::{Read, Write};
+        let sock = daemon_socket_path();
+        if let Ok(mut stream) = std::os::unix::net::UnixStream::connect(&sock) {
+            let _ = stream.write_all(b"{\"event\":\"__shutdown\"}\n");
+            let mut buf = [0u8; 64];
+            let _ = stream.read(&mut buf);
+        }
+        let _ = std::fs::remove_file(daemon_pid_path());
+        let _ = std::fs::remove_file(daemon_socket_path());
+    }
+
+    fn recent_log_lines(max_lines: usize) -> Vec<String> {
+        let log_path = daemon_dir().join("events.log");
+        let Ok(content) = std::fs::read_to_string(&log_path) else {
+            return Vec::new();
+        };
+        content.lines().rev().take(max_lines).map(String::from).collect::<Vec<_>>()
+            .into_iter().rev().collect()
+    }
+
+    fn format_uptime(secs: u64) -> String {
+        if secs < 60 {
+            format!("{}s", secs)
+        } else if secs < 3600 {
+            format!("{}m {}s", secs / 60, secs % 60)
+        } else {
+            format!("{}h {}m", secs / 3600, (secs % 3600) / 60)
+        }
+    }
+
+    // ── TUI state ───────────────────────────────────────────────────────────
+
+    struct TuiState {
+        daemon: DaemonStatus,
+        muted: bool,
+        drone_muted: bool,
+        current_seed: Option<String>,
+        current_quantize: Option<u32>,
+        recent_events: Vec<ParsedEvent>,
+        all_events: Vec<ParsedEvent>,
+        event_count: usize,
+        new_event_time: Option<Instant>,
+        voice_activity: Vec<(String, Instant)>, // (repo, last_event_time)
+        activity: ActivityData,
+        timescale: TimeScale,
+        time_offset: i64,       // bucket offset for panning (negative = past)
+        stream_scroll: usize,   // how many events scrolled up from bottom
+        seed_list: ListState,
+        seeds_open: bool,
+        // Panel rects from last render (for mouse hit-testing)
+        rect_activity: Rect,
+        rect_stream: Rect,
+        rect_status: Rect,
+        activity_cols: usize,  // last-known inner width for activity panel
+        last_poll: Instant,
+    }
+
+    impl TuiState {
+        fn new() -> Self {
+            let mut seed_list = ListState::default();
+            seed_list.select(Some(0));
+            Self {
+                daemon: DaemonStatus::default(),
+                muted: false,
+                drone_muted: false,
+                current_seed: None,
+                current_quantize: None,
+                recent_events: Vec::new(),
+                all_events: Vec::new(),
+                event_count: 0,
+                new_event_time: None,
+                voice_activity: Vec::new(),
+                activity: ActivityData { per_category: Vec::new(), total: vec![0; 60], total_events: 0 },
+                timescale: TimeScale::Hour1,
+                time_offset: 0,
+                stream_scroll: 0,
+                seed_list,
+                seeds_open: false,
+                rect_activity: Rect::default(),
+                rect_stream: Rect::default(),
+                rect_status: Rect::default(),
+                activity_cols: 80, // reasonable default until first render
+                last_poll: Instant::now() - Duration::from_secs(10),
+            }
+        }
+
+        fn poll_daemon(&mut self) {
+            self.daemon = query_daemon_status();
+            self.muted = is_muted();
+            self.drone_muted = is_drone_muted();
+            self.current_seed = get_seed();
+            self.current_quantize = get_quantize();
+
+            let raw_all = recent_log_lines(self.timescale.log_lines());
+            // Filter recent events: only those from the last 24 hours (avoids stale events)
+            let now_epoch = {
+                use std::time::SystemTime;
+                SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap_or_default().as_secs()
+            };
+            let max_age_secs = 24 * 3600; // 24 hours
+            let raw_recent: Vec<&String> = raw_all.iter().rev()
+                .filter(|line| {
+                    let parsed = ParsedEvent::parse(line);
+                    parse_timestamp_epoch(&parsed.timestamp)
+                        .is_some_and(|epoch| now_epoch.saturating_sub(epoch) < max_age_secs)
+                })
+                .take(200)
+                .collect::<Vec<_>>().into_iter().rev().collect();
+
+            let new_count = raw_recent.len();
+            if new_count > self.event_count {
+                self.new_event_time = Some(Instant::now());
+                for line in &raw_recent[self.event_count.min(new_count)..] {
+                    let parsed = ParsedEvent::parse(line);
+                    if let Some(entry) = self.voice_activity.iter_mut().find(|(r, _)| *r == parsed.repo) {
+                        entry.1 = Instant::now();
+                    } else if !parsed.repo.is_empty() {
+                        self.voice_activity.push((parsed.repo.clone(), Instant::now()));
+                    }
+                }
+            }
+            self.event_count = new_count;
+
+            self.all_events = raw_all.iter().map(|l| ParsedEvent::parse(l)).collect();
+            self.recent_events = raw_recent.iter().map(|l| ParsedEvent::parse(l)).collect();
+            self.activity = build_activity_data(&self.all_events, self.timescale, self.time_offset, self.activity_cols);
+            self.last_poll = Instant::now();
+
+            if let Some(ref name) = self.current_seed {
+                if let Some(idx) = SEED_PRESETS.iter().position(|p| p.name == name) {
+                    self.seed_list.select(Some(idx));
+                }
+            }
+        }
+
+        fn selected_seed_name(&self) -> Option<&str> {
+            self.seed_list.selected()
+                .and_then(|i| SEED_PRESETS.get(i))
+                .map(|p| p.name)
+        }
+
+        fn grid_label(&self) -> &'static str {
+            match self.current_quantize {
+                Some(d) => subdiv_label(super::quantize_denom_to_subdiv(d)),
+                None => "auto",
+            }
+        }
+    }
+
+    // ── Keyboard handling ───────────────────────────────────────────────────
+
+    enum Action { Quit, Continue }
+
+    fn handle_key(key: crossterm::event::KeyEvent, state: &mut TuiState) -> Action {
+        use crossterm::event::{KeyCode, KeyModifiers};
+
+        if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
+            return Action::Quit;
+        }
+
+        // Seed overlay captures keys when open
+        if state.seeds_open {
+            match key.code {
+                KeyCode::Esc | KeyCode::Char('p') => { state.seeds_open = false; }
+                KeyCode::Char('j') | KeyCode::Down => {
+                    let i = state.seed_list.selected().unwrap_or(0);
+                    state.seed_list.select(Some(if i + 1 >= SEED_PRESETS.len() { 0 } else { i + 1 }));
+                }
+                KeyCode::Char('k') | KeyCode::Up => {
+                    let i = state.seed_list.selected().unwrap_or(0);
+                    state.seed_list.select(Some(if i == 0 { SEED_PRESETS.len() - 1 } else { i - 1 }));
+                }
+                KeyCode::Enter => {
+                    if let Some(name) = state.selected_seed_name() {
+                        let _ = std::fs::create_dir_all(daemon_dir());
+                        let _ = std::fs::write(seed_file_path(), name);
+                        state.current_seed = Some(name.to_string());
+                    }
+                    state.seeds_open = false;
+                }
+                KeyCode::Char('x') => {
+                    let path = seed_file_path();
+                    if path.exists() { let _ = std::fs::remove_file(&path); }
+                    state.current_seed = None;
+                    state.seeds_open = false;
+                }
+                _ => {}
+            }
+            return Action::Continue;
+        }
+
+        match key.code {
+            KeyCode::Char('q') | KeyCode::Esc => Action::Quit,
+            KeyCode::Char('m') => {
+                if state.muted { let _ = std::fs::remove_file(mute_file_path()); }
+                else { let _ = std::fs::create_dir_all(daemon_dir()); let _ = std::fs::write(mute_file_path(), ""); }
+                state.muted = !state.muted;
+                Action::Continue
+            }
+            KeyCode::Char('d') => {
+                if state.drone_muted { let _ = std::fs::remove_file(drone_mute_path()); }
+                else { let _ = std::fs::create_dir_all(daemon_dir()); let _ = std::fs::write(drone_mute_path(), ""); }
+                state.drone_muted = !state.drone_muted;
+                Action::Continue
+            }
+            KeyCode::Char('s') => {
+                start_daemon();
+                std::thread::sleep(Duration::from_millis(500));
+                state.poll_daemon();
+                Action::Continue
+            }
+            KeyCode::Char('S') => {
+                stop_daemon();
+                std::thread::sleep(Duration::from_millis(200));
+                state.poll_daemon();
+                Action::Continue
+            }
+            KeyCode::Char('p') => { state.seeds_open = true; Action::Continue }
+            KeyCode::Char('g') => {
+                let next = match state.current_quantize {
+                    None => Some(32), Some(32) => Some(16), Some(16) => Some(8),
+                    Some(8) => Some(4), Some(4) => Some(0), Some(0) | Some(_) => None,
+                };
+                match next {
+                    Some(d) => { let _ = std::fs::create_dir_all(daemon_dir()); let _ = std::fs::write(quantize_file_path(), d.to_string()); }
+                    None => { let _ = std::fs::remove_file(quantize_file_path()); }
+                }
+                state.current_quantize = next;
+                Action::Continue
+            }
+            // Zoom activity histogram
+            KeyCode::Char('+') | KeyCode::Char('=') => {
+                state.timescale = state.timescale.zoom_in();
+                state.time_offset = 0; // reset pan on zoom change
+                state.poll_daemon();
+                Action::Continue
+            }
+            KeyCode::Char('-') => {
+                state.timescale = state.timescale.zoom_out();
+                state.time_offset = 0;
+                state.poll_daemon();
+                Action::Continue
+            }
+
+            // Pan activity histogram in time
+            KeyCode::Left => {
+                state.time_offset += 5;
+                state.activity = build_activity_data(&state.all_events, state.timescale, state.time_offset, state.activity_cols);
+                Action::Continue
+            }
+            KeyCode::Right => {
+                state.time_offset = (state.time_offset - 5).max(0);
+                state.activity = build_activity_data(&state.all_events, state.timescale, state.time_offset, state.activity_cols);
+                Action::Continue
+            }
+
+            // Home = jump to present
+            KeyCode::Home => {
+                state.time_offset = 0;
+                state.stream_scroll = 0;
+                state.activity = build_activity_data(&state.all_events, state.timescale, 0, state.activity_cols);
+                Action::Continue
+            }
+
+            // Stream scrolling
+            KeyCode::Char('j') | KeyCode::Down => {
+                state.stream_scroll = state.stream_scroll.saturating_sub(1);
+                Action::Continue
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                state.stream_scroll = state.stream_scroll.saturating_add(1)
+                    .min(state.recent_events.len().saturating_sub(1));
+                Action::Continue
+            }
+            KeyCode::PageDown => {
+                state.stream_scroll = state.stream_scroll.saturating_sub(10);
+                Action::Continue
+            }
+            KeyCode::PageUp => {
+                state.stream_scroll = state.stream_scroll.saturating_add(10)
+                    .min(state.recent_events.len().saturating_sub(1));
+                Action::Continue
+            }
+            KeyCode::End => {
+                state.stream_scroll = 0; // jump to newest
+                Action::Continue
+            }
+
+            KeyCode::Char('r') => {
+                state.recent_events.clear();
+                state.event_count = 0;
+                state.new_event_time = None;
+                state.voice_activity.clear();
+                state.stream_scroll = 0;
+                Action::Continue
+            }
+            _ => Action::Continue,
+        }
+    }
+
+    fn handle_mouse(mouse: crossterm::event::MouseEvent, state: &mut TuiState) {
+        use crossterm::event::{MouseEventKind, MouseButton};
+
+        let col = mouse.column;
+        let row = mouse.row;
+
+        match mouse.kind {
+            MouseEventKind::ScrollUp => {
+                if state.rect_activity.contains((col, row).into()) {
+                    // Scroll up on activity = pan backward in time
+                    state.time_offset += 3;
+                    state.activity = build_activity_data(&state.all_events, state.timescale, state.time_offset, state.activity_cols);
+                } else if state.rect_stream.contains((col, row).into()) {
+                    // Scroll up on stream = show older events
+                    state.stream_scroll = state.stream_scroll.saturating_add(3)
+                        .min(state.recent_events.len().saturating_sub(1));
+                }
+            }
+            MouseEventKind::ScrollDown => {
+                if state.rect_activity.contains((col, row).into()) {
+                    // Scroll down on activity = pan forward in time (toward present)
+                    state.time_offset = (state.time_offset - 3).max(0);
+                    state.activity = build_activity_data(&state.all_events, state.timescale, state.time_offset, state.activity_cols);
+                } else if state.rect_stream.contains((col, row).into()) {
+                    // Scroll down on stream = show newer events
+                    state.stream_scroll = state.stream_scroll.saturating_sub(3);
+                }
+            }
+            MouseEventKind::Down(MouseButton::Left) => {
+                if state.rect_status.contains((col, row).into()) {
+                    // Click on status bar — detect which parameter was clicked
+                    // Build a rough column map from the status spans
+                    handle_status_click(col, state);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Detect which status bar element was clicked and toggle/open it
+    fn handle_status_click(col: u16, state: &mut TuiState) {
+        // Status bar layout (approximate character positions after border):
+        // "● RUNNING  PID 1234  up 2h  3 voices  seed: shadow  grid: 1/16  MUTED  drone off"
+        // The spans are variable-width, so we use rough column ranges.
+        // These are estimates — good enough for click detection.
+        let inner_col = col.saturating_sub(1); // account for border
+
+        // Scan the rendered text to find approximate positions
+        // We look for keywords in the status line
+        let status_text = format!(
+            "● {}  PID {}  up {}  {} voice{}  seed: {}  grid: {}{}{}",
+            if state.daemon.running { "RUNNING" } else { "STOPPED" },
+            state.daemon.pid,
+            format_uptime(state.daemon.uptime_secs),
+            state.daemon.active_voices.len(),
+            if state.daemon.active_voices.len() == 1 { "" } else { "s" },
+            state.current_seed.as_deref().unwrap_or("default"),
+            state.grid_label(),
+            if state.muted { "  MUTED" } else { "" },
+            if state.drone_muted && !state.muted { "  drone off" } else { "" },
+        );
+
+        let col = inner_col as usize;
+
+        // Find "seed:" position
+        if let Some(seed_pos) = status_text.find("seed:") {
+            if col >= seed_pos && col < seed_pos + 20 {
+                state.seeds_open = true;
+                return;
+            }
+        }
+
+        // Find "grid:" position
+        if let Some(grid_pos) = status_text.find("grid:") {
+            if col >= grid_pos && col < grid_pos + 12 {
+                // Cycle grid
+                let next = match state.current_quantize {
+                    None => Some(32), Some(32) => Some(16), Some(16) => Some(8),
+                    Some(8) => Some(4), Some(4) => Some(0), Some(0) | Some(_) => None,
+                };
+                match next {
+                    Some(d) => { let _ = std::fs::create_dir_all(daemon_dir()); let _ = std::fs::write(quantize_file_path(), d.to_string()); }
+                    None => { let _ = std::fs::remove_file(quantize_file_path()); }
+                }
+                state.current_quantize = next;
+                return;
+            }
+        }
+
+        // Find "MUTED" position
+        if let Some(mute_pos) = status_text.find("MUTED") {
+            if col >= mute_pos && col < mute_pos + 6 {
+                let _ = std::fs::remove_file(mute_file_path());
+                state.muted = false;
+                return;
+            }
+        }
+
+        // Find "drone off" position
+        if let Some(drone_pos) = status_text.find("drone off") {
+            if col >= drone_pos && col < drone_pos + 10 {
+                let _ = std::fs::remove_file(drone_mute_path());
+                state.drone_muted = false;
+                return;
+            }
+        }
+
+        // Find "STOPPED" — click to start
+        if let Some(stop_pos) = status_text.find("STOPPED") {
+            if col >= stop_pos && col < stop_pos + 8 {
+                start_daemon();
+                std::thread::sleep(Duration::from_millis(500));
+                state.poll_daemon();
+                return;
+            }
+        }
+
+        // Find "RUNNING" — show it's clickable but don't stop accidentally
+        // (stopping requires Shift+S to avoid accidents)
+    }
+
+    // ── Layout & rendering ──────────────────────────────────────────────────
+
+    fn ui(frame: &mut ratatui::Frame, state: &mut TuiState) {
+        let area = frame.area();
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(3),   // status bar
+                Constraint::Length(5),   // activity bars (per-category)
+                Constraint::Min(8),     // merged voice+events stream
+                Constraint::Length(1),   // keybind footer
+            ])
+            .split(area);
+
+        // Store rects for mouse hit-testing
+        state.rect_status = chunks[0];
+        state.rect_activity = chunks[1];
+        state.rect_stream = chunks[2];
+
+        render_status_bar(frame, state, chunks[0]);
+        render_activity(frame, state, chunks[1]);
+        render_stream(frame, state, chunks[2]);
+        render_footer(frame, state, chunks[3]);
+
+        if state.seeds_open {
+            render_seed_overlay(frame, state, area);
+        }
+    }
+
+    fn render_status_bar(frame: &mut ratatui::Frame, state: &TuiState, area: Rect) {
+        let daemon_indicator = if state.daemon.running {
+            Span::styled("● RUNNING", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD))
+        } else {
+            Span::styled("○ STOPPED", Style::default().fg(Color::DarkGray))
+        };
+        let pid_span = if state.daemon.running {
+            Span::styled(format!("  PID {}  up {}", state.daemon.pid, format_uptime(state.daemon.uptime_secs)), Style::default().fg(Color::DarkGray))
+        } else { Span::raw("") };
+        let voice_count = state.daemon.active_voices.len();
+        let voices_span = if voice_count > 0 {
+            Span::styled(format!("  {} voice{}", voice_count, if voice_count == 1 { "" } else { "s" }), Style::default().fg(Color::Cyan))
+        } else { Span::styled("  no voices", Style::default().fg(Color::DarkGray)) };
+        let seed_span = match &state.current_seed {
+            Some(name) => Span::styled(format!("  seed: {}", name), Style::default().fg(Color::Yellow)),
+            None => Span::styled("  seed: default", Style::default().fg(Color::DarkGray)),
+        };
+        let grid_span = Span::styled(format!("  grid: {}", state.grid_label()), Style::default().fg(Color::Magenta));
+        let mute_span = if state.muted { Span::styled("  MUTED", Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)) } else { Span::raw("") };
+        let drone_span = if state.drone_muted && !state.muted { Span::styled("  drone off", Style::default().fg(Color::DarkGray)) } else { Span::raw("") };
+
+        let line = Line::from(vec![daemon_indicator, pid_span, voices_span, seed_span, grid_span, mute_span, drone_span]);
+        let block = Block::default().borders(Borders::BOTTOM)
+            .title(Span::styled(" branch-tone ", Style::default().fg(Color::White).add_modifier(Modifier::BOLD)));
+        frame.render_widget(Paragraph::new(line).block(block), area);
+    }
+
+    /// Stacked per-category activity bars
+    fn render_activity(frame: &mut ratatui::Frame, state: &mut TuiState, area: Rect) {
+        let scale_label = state.timescale.label();
+        let offset_label = if state.time_offset > 0 {
+            let offset_secs = state.time_offset as u64 * state.timescale.bucket_secs(state.activity_cols as u64);
+            format!(" ◀ −{} ", format_uptime(offset_secs))
+        } else {
+            " now ".to_string()
+        };
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .title(Line::from(vec![
+                Span::styled(" Activity ", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
+                Span::styled(format!("[−] {} [+]", scale_label), Style::default().fg(Color::DarkGray)),
+                Span::styled(
+                    offset_label,
+                    Style::default().fg(if state.time_offset > 0 { Color::Yellow } else { Color::DarkGray }),
+                ),
+            ]))
+            .title_bottom(Line::from(vec![
+                Span::styled(format!(" {} events ", state.activity.total_events), Style::default().fg(Color::Green)),
+                Span::styled("│", Style::default().fg(Color::DarkGray)),
+                Span::styled(" ■", Style::default().fg(Color::Green)),
+                Span::styled("tool ", Style::default().fg(Color::DarkGray)),
+                Span::styled("■", Style::default().fg(Color::Yellow)),
+                Span::styled("prompt ", Style::default().fg(Color::DarkGray)),
+                Span::styled("■", Style::default().fg(Color::Cyan)),
+                Span::styled("session ", Style::default().fg(Color::DarkGray)),
+                Span::styled("■", Style::default().fg(Color::Blue)),
+                Span::styled("agent ", Style::default().fg(Color::DarkGray)),
+            ]));
+
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+        if inner.height == 0 || inner.width == 0 { return; }
+
+        // Rebuild activity data if terminal width changed
+        let new_cols = inner.width as usize;
+        if new_cols != state.activity_cols {
+            state.activity_cols = new_cols;
+            state.activity = build_activity_data(&state.all_events, state.timescale, state.time_offset, new_cols);
+        }
+
+        let max_val = state.activity.total.iter().copied().max().unwrap_or(1).max(1);
+        let col_height = inner.height as u64;
+
+        for col in 0..inner.width as usize {
+            if col >= state.activity.total.len() { break; }
+            let mut y_cursor = inner.y + inner.height;
+            for (cat, buckets) in &state.activity.per_category {
+                if col >= buckets.len() { continue; }
+                let val = buckets[col];
+                if val == 0 { continue; }
+                let bar_h = ((val * col_height) / max_val).max(if val > 0 { 1 } else { 0 }) as u16;
+                for _dy in 0..bar_h {
+                    if y_cursor == inner.y { break; }
+                    y_cursor -= 1;
+                    let x = inner.x + col as u16;
+                    if x < inner.x + inner.width && y_cursor >= inner.y {
+                        frame.buffer_mut()[(x, y_cursor)].set_char('█').set_fg(cat.color());
+                    }
+                }
+            }
+        }
+    }
+
+    /// Merged voice+events stream — events colored by voice
+    fn render_stream(frame: &mut ratatui::Frame, state: &TuiState, area: Rect) {
+        let flash_active = state.new_event_time.is_some_and(|t| t.elapsed().as_secs_f32() < 2.0);
+        let border_color = if flash_active { Color::Green } else { Color::DarkGray };
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(border_color))
+            .title(Span::styled(" Stream ", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)));
+
+        if state.recent_events.is_empty() {
+            let msg = if state.daemon.running { "Waiting for events..." } else { "Daemon not running — press [s] to start" };
+            frame.render_widget(Paragraph::new(Span::styled(msg, Style::default().fg(Color::DarkGray))).block(block), area);
+            return;
+        }
+
+        let max_visible = (area.height as usize).saturating_sub(2);
+        // Apply scroll offset: scroll=0 means newest at bottom, scroll=N means N events scrolled up
+        let end = state.recent_events.len().saturating_sub(state.stream_scroll);
+        let start = end.saturating_sub(max_visible);
+        let visible_events = &state.recent_events[start..end];
+
+        let now = Instant::now();
+        let total = state.recent_events.len();
+
+        let lines: Vec<Line> = visible_events.iter().enumerate().map(|(i, evt)| {
+            let recency = i as f32 / (visible_events.len().max(1) as f32);
+            let is_newest = i == visible_events.len() - 1 && flash_active;
+
+            let voice_col = voice_color_for_repo(&evt.repo, &state.daemon.active_voices);
+            let voice_age = state.voice_activity.iter()
+                .find(|(r, _)| *r == evt.repo)
+                .map(|(_, t)| now.duration_since(*t).as_secs_f32());
+
+            let lane_char = if is_newest { "█" } else if voice_age.is_some_and(|a| a < 2.0) { "▓" } else if recency > 0.7 { "▒" } else { "░" };
+            let lane_color = if is_newest { Color::White } else { voice_col };
+            let time_str = if evt.timestamp.len() > 11 { &evt.timestamp[11..] } else { &evt.timestamp };
+            let type_color = if is_newest { Color::White } else if recency > 0.7 { evt.type_color() } else { Color::DarkGray };
+            let repo_color = if is_newest { Color::White } else if recency > 0.5 { voice_col } else { Color::DarkGray };
+            let time_color = if is_newest { Color::White } else { Color::DarkGray };
+            let branch_color = if is_newest { Color::White } else { Color::DarkGray };
+
+            Line::from(vec![
+                Span::styled(lane_char, Style::default().fg(lane_color)),
+                Span::styled(format!(" {} ", time_str), Style::default().fg(time_color)),
+                Span::styled(format!("{:<7}", evt.type_label()), Style::default().fg(type_color).add_modifier(if is_newest { Modifier::BOLD } else { Modifier::empty() })),
+                Span::styled(format!(" {}", evt.repo), Style::default().fg(repo_color)),
+                Span::styled(format!("/{}", evt.branch), Style::default().fg(branch_color)),
+            ])
+        }).collect();
+
+        let scroll_hint = if state.stream_scroll > 0 {
+            format!(" ▲{} ", state.stream_scroll)
+        } else { String::new() };
+        let title_right = format!(" {}/{}{} [r]eset ", visible_events.len(), total, scroll_hint);
+        let block = block.title_bottom(Line::from(Span::styled(title_right, Style::default().fg(
+            if state.stream_scroll > 0 { Color::Yellow } else { Color::DarkGray }
+        ))).alignment(ratatui::layout::Alignment::Right));
+        frame.render_widget(Paragraph::new(lines).block(block), area);
+    }
+
+    fn render_seed_overlay(frame: &mut ratatui::Frame, state: &TuiState, area: Rect) {
+        let overlay_w = 50u16.min(area.width.saturating_sub(4));
+        let overlay_h = 20u16.min(area.height.saturating_sub(4));
+        let x = (area.width.saturating_sub(overlay_w)) / 2 + area.x;
+        let y = (area.height.saturating_sub(overlay_h)) / 2 + area.y;
+        let overlay = Rect::new(x, y, overlay_w, overlay_h);
+
+        frame.render_widget(ratatui::widgets::Clear, overlay);
+
+        let items: Vec<ListItem> = SEED_PRESETS.iter().map(|preset| {
+            let is_active = state.current_seed.as_deref() == Some(preset.name);
+            let marker = if is_active { "▸ " } else { "  " };
+            let name_style = if is_active {
+                Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)
+            } else { Style::default().fg(Color::White) };
+            let groove = format!(" sw:{:.0}% hu:{:.0}% {}", preset.swing * 100.0, preset.humanize * 100.0, subdiv_label(preset.quantize_subdiv));
+            ListItem::new(Line::from(vec![
+                Span::raw(marker),
+                Span::styled(format!("{:<10}", preset.name), name_style),
+                Span::styled(groove, Style::default().fg(Color::DarkGray)),
+            ]))
+        }).collect();
+
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Yellow))
+            .title(Span::styled(" Seeds ", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)))
+            .title_bottom(Line::from(Span::styled(" [j/k] navigate  [Enter] apply  [x] clear  [Esc] close ", Style::default().fg(Color::DarkGray))));
+
+        let list = List::new(items).block(block).highlight_style(Style::default().add_modifier(Modifier::REVERSED));
+        frame.render_stateful_widget(list, overlay, &mut state.seed_list.clone());
+    }
+
+    fn render_footer(frame: &mut ratatui::Frame, state: &TuiState, area: Rect) {
+        let mute_key = if state.muted { "[m]unmute" } else { "[m]ute" };
+        let drone_key = if state.drone_muted { "[d]rone on" } else { "[d]rone off" };
+        let daemon_key = if state.daemon.running { "[S]top" } else { "[s]tart" };
+        let line = Line::from(vec![
+            Span::styled(format!(" {} ", mute_key), Style::default().fg(Color::White)),
+            Span::styled("│", Style::default().fg(Color::DarkGray)),
+            Span::styled(format!(" {} ", drone_key), Style::default().fg(Color::White)),
+            Span::styled("│", Style::default().fg(Color::DarkGray)),
+            Span::styled(format!(" {} daemon ", daemon_key), Style::default().fg(Color::White)),
+            Span::styled("│", Style::default().fg(Color::DarkGray)),
+            Span::styled(format!(" [g]rid: {} ", state.grid_label()), Style::default().fg(Color::White)),
+            Span::styled("│", Style::default().fg(Color::DarkGray)),
+            Span::styled(" [p]alette ", Style::default().fg(Color::Yellow)),
+            Span::styled("│", Style::default().fg(Color::DarkGray)),
+            Span::styled(" [+/-]zoom ", Style::default().fg(Color::White)),
+            Span::styled("│", Style::default().fg(Color::DarkGray)),
+            Span::styled(" [q]uit ", Style::default().fg(Color::White)),
+        ]);
+        frame.render_widget(Paragraph::new(line), area);
+    }
+
+    // ── Entry point ─────────────────────────────────────────────────────────
+
+    pub fn run() -> Result<()> {
+        let _guard = super::RawModeGuard::enter()?;
+        // Enable mouse capture for scroll and click
+        crossterm::execute!(std::io::stdout(), crossterm::event::EnableMouseCapture)?;
+        let backend = CrosstermBackend::new(std::io::stdout());
+        let mut terminal = Terminal::new(backend).context("Failed to initialize terminal")?;
+        let mut state = TuiState::new();
+
+        let result = (|| -> Result<()> {
+            loop {
+                if state.last_poll.elapsed() > Duration::from_secs(2) {
+                    state.poll_daemon();
+                }
+                terminal.draw(|frame| ui(frame, &mut state))?;
+                if crossterm::event::poll(Duration::from_millis(200))? {
+                    match crossterm::event::read()? {
+                        crossterm::event::Event::Key(key) => {
+                            if key.kind != crossterm::event::KeyEventKind::Press { continue; }
+                            match handle_key(key, &mut state) {
+                                Action::Quit => break,
+                                Action::Continue => {}
+                            }
+                        }
+                        crossterm::event::Event::Mouse(mouse) => {
+                            handle_mouse(mouse, &mut state);
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            Ok(())
+        })();
+
+        // Always disable mouse capture on exit
+        crossterm::execute!(std::io::stdout(), crossterm::event::DisableMouseCapture)?;
+        result
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn format_uptime_seconds() { assert_eq!(format_uptime(45), "45s"); }
+        #[test]
+        fn format_uptime_minutes() { assert_eq!(format_uptime(125), "2m 5s"); }
+        #[test]
+        fn format_uptime_hours() { assert_eq!(format_uptime(3725), "1h 2m"); }
+
+        #[test]
+        fn grid_label_auto() { assert_eq!(TuiState::new().grid_label(), "auto"); }
+
+        #[test]
+        fn grid_label_values() {
+            let mut s = TuiState::new();
+            s.current_quantize = Some(32); assert_eq!(s.grid_label(), "1/32");
+            s.current_quantize = Some(16); assert_eq!(s.grid_label(), "1/16");
+            s.current_quantize = Some(8); assert_eq!(s.grid_label(), "1/8");
+            s.current_quantize = Some(4); assert_eq!(s.grid_label(), "1/4");
+        }
+
+        #[test]
+        fn seed_list_initial_selection() {
+            let s = TuiState::new();
+            assert_eq!(s.seed_list.selected(), Some(0));
+            assert_eq!(s.selected_seed_name(), Some("shadow"));
+        }
+
+        #[test]
+        fn parse_event_line() {
+            let evt = ParsedEvent::parse("2026-04-01T21:58:29 PreToolUse branch-tone tui");
+            assert_eq!(evt.event_type, "PreToolUse");
+            assert_eq!(evt.repo, "branch-tone");
+            assert_eq!(evt.type_label(), "TOOL");
+            assert_eq!(evt.type_color(), Color::Green);
+        }
+
+        #[test]
+        fn parse_event_types_colored() {
+            assert_eq!(ParsedEvent::parse("T SessionStart r b").type_color(), Color::Cyan);
+            assert_eq!(ParsedEvent::parse("T PostToolUseFailure r b").type_color(), Color::Red);
+            assert_eq!(ParsedEvent::parse("T UserPromptSubmit r b").type_color(), Color::Yellow);
+            assert_eq!(ParsedEvent::parse("T Stop r b").type_color(), Color::Magenta);
+        }
+
+        #[test]
+        fn parse_timestamp_epoch_valid() {
+            let e = parse_timestamp_epoch("2026-04-01T21:58:29").unwrap();
+            assert!(e > 1_774_000_000 && e < 1_780_000_000);
+        }
+
+        #[test]
+        fn parse_timestamp_epoch_invalid() {
+            assert!(parse_timestamp_epoch("garbage").is_none());
+            assert!(parse_timestamp_epoch("2026-04-01").is_none());
+        }
+
+        #[test]
+        fn activity_data_empty() {
+            let d = build_activity_data(&[], TimeScale::Hour1, 0, 60);
+            assert_eq!(d.total.len(), 60);
+            assert_eq!(d.total_events, 0);
+            assert_eq!(d.per_category.len(), 5);
+        }
+
+        #[test]
+        fn timescale_zoom_in_out() {
+            assert_eq!(TimeScale::Hour1.zoom_in(), TimeScale::Min15);
+            assert_eq!(TimeScale::Hour1.zoom_out(), TimeScale::Hour4);
+            assert_eq!(TimeScale::Min5.zoom_in(), TimeScale::Min5); // can't zoom further
+            assert_eq!(TimeScale::Hour24.zoom_out(), TimeScale::Hour24); // can't zoom further
+        }
+
+        #[test]
+        fn timescale_bucket_secs() {
+            // With 60 columns (default-like width):
+            assert_eq!(TimeScale::Min5.bucket_secs(60), 5);       // 5s per bucket
+            assert_eq!(TimeScale::Min15.bucket_secs(60), 15);     // 15s per bucket
+            assert_eq!(TimeScale::Hour1.bucket_secs(60), 60);     // 1min per bucket
+            assert_eq!(TimeScale::Hour4.bucket_secs(60), 240);    // 4min per bucket
+            assert_eq!(TimeScale::Hour24.bucket_secs(60), 1440);  // 24min per bucket
+            // With 120 columns (wide terminal): finer granularity
+            assert_eq!(TimeScale::Hour1.bucket_secs(120), 30);    // 30s per bucket
+        }
+
+        #[test]
+        fn event_type_categories() {
+            assert_eq!(ParsedEvent::parse("T PreToolUse r b").type_category(), EventTypeCategory::Tool);
+            assert_eq!(ParsedEvent::parse("T UserPromptSubmit r b").type_category(), EventTypeCategory::Prompt);
+            assert_eq!(ParsedEvent::parse("T SessionStart r b").type_category(), EventTypeCategory::Session);
+            assert_eq!(ParsedEvent::parse("T SubagentStart r b").type_category(), EventTypeCategory::Agent);
+            assert_eq!(ParsedEvent::parse("T Notification r b").type_category(), EventTypeCategory::Other);
+        }
+
+        #[test]
+        fn voice_color_assignment() {
+            let voices = vec![(0, "repo-a".into(), "main".into()), (1, "repo-b".into(), "dev".into())];
+            assert_eq!(voice_color_for_repo("repo-a", &voices), VOICE_COLORS[0]);
+            assert_eq!(voice_color_for_repo("repo-b", &voices), VOICE_COLORS[1]);
+            assert_eq!(voice_color_for_repo("unknown", &voices), Color::DarkGray);
+        }
+
+        #[test]
+        fn initial_state_seeds_closed() {
+            let s = TuiState::new();
+            assert!(!s.seeds_open);
+            assert!(s.voice_activity.is_empty());
+            assert_eq!(s.event_count, 0);
+        }
+
+        #[test]
+        fn category_labels() {
+            assert_eq!(EventTypeCategory::Tool.label(), "tool");
+            assert_eq!(EventTypeCategory::Prompt.label(), "prompt");
+            assert_eq!(EventTypeCategory::Session.label(), "session");
+        }
+
+        #[test]
+        fn time_offset_default_zero() {
+            let s = TuiState::new();
+            assert_eq!(s.time_offset, 0);
+            assert_eq!(s.stream_scroll, 0);
+        }
+
+        #[test]
+        fn zoom_resets_offset() {
+            // Verify that zoom_in/out return different scales (offset reset is in key handler)
+            let scale = TimeScale::Hour1;
+            assert_ne!(scale.zoom_in(), scale);
+            assert_ne!(scale.zoom_out(), scale);
+        }
+    }
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `branch-tone tui` subcommand — a ratatui-powered terminal dashboard that connects to the running daemon as a read-only client
- **Deep hook integration**: extracts 30+ fields from Claude Code hook JSON (tool_name, agent_type, error_msg, session_id) — previously discarded
- **27 hook events** (up from 18): StopFailure, PermissionDenied, PostCompact, Setup, TaskCreated, CwdChanged, FileChanged, Elicitation, ElicitationResult
- **Tool-aware synthesis**: Read=bright, Bash=aggressive, Write=warm, Agent=airy, Web=ethereal — each tool type gets unique timbre via filter/detune/harmonics
- **Agent register mapping**: researcher=low, worker=center, validator=high, scout=highest — bass events shift by agent type
- **Error dissonance**: tritone + minor 2nd + pitch drop on failure events
- **TUI enrichment**: tool badges `[Read]`, agent badges `<worker>`, tool-aware labels (READ/WRITE/BASH), activity histogram with timestamps and scale
- Feature-gated behind `--features tui` — zero impact on default build
- 22 new tests (169 total with tui feature), all 3 design docs updated

## Test plan
- [x] `cargo test` — 147 pass (default)
- [x] `cargo test --features tray` — 148 pass
- [x] `cargo test --features tui` — 169 pass
- [x] `cargo build --features tui` — zero new warnings
- [x] All 3 build targets compile clean (default, tray, tui)
- [ ] Run `branch-tone tui` with daemon running, verify tool badges and agent badges appear in stream
- [ ] Trigger errors, verify dissonant sound
- [ ] Verify activity histogram shows timestamps and scale



Generated with [PDS](https://github.com/rmzi/portable-dev-system)